### PR TITLE
Remove duplicate labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/owl/catalog-v001.xml
+.DS_Store

--- a/owl/cemo.owl
+++ b/owl/cemo.owl
@@ -655,8 +655,7 @@ Entities which are in time are related to the corresponding temporal regions by 
         </rdfs:subClassOf>
         <terms:description xml:lang="en">A quality that inheres in an organism population and is the infection incidence proportion per unit time.</terms:description>
         <terms:description xml:lang="en">It is the number of new events that occurs in a defined time period in a geographical area.</terms:description>
-        <rdfs:label xml:lang="en">incidence rate</rdfs:label>
-        <rdfs:label xml:lang="en">infection rate</rdfs:label>
+        <rdfs:label xml:lang="en">infection incidence rate</rdfs:label>
     </owl:Class>
     
 
@@ -735,7 +734,6 @@ Entities which are in time are related to the corresponding temporal regions by 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000665">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/cemo.owl#interpretation"/>
-        <rdfs:label xml:lang="en">infection source</rdfs:label>
         <rdfs:label xml:lang="en">source of infection</rdfs:label>
     </owl:Class>
     
@@ -954,8 +952,7 @@ Entities which are in time are related to the corresponding temporal regions by 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"/>
         <terms:description xml:lang="en">A population is a group of material entities consisting of individuals which share a particular characteristic such as inhabiting a particular region or area or ability to interbreed.</terms:description>
         <terms:description xml:lang="en">Statistical sample size is a count evaluating the number of individual experimental units.</terms:description>
-        <rdfs:label xml:lang="en">population size</rdfs:label>
-        <rdfs:label xml:lang="en">sample size</rdfs:label>
+        <rdfs:label xml:lang="en">study group population size</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
This PR removes three instances where there are duplicate labels, which makes it impossible to use ROBOT to convert this ontology into OBO, JSON, etc.

I'm curious though, how did this situation even happen? Were these terms imported? If so, using what tool?

Even more worrisome, with a spot check on the STATO term, the labels and the description don't even appear to be corresponding to the term from the ontology (https://ontobee.org/ontology/STATO?iri=http://purl.obolibrary.org/obo/STATO_0000088)