### PR TITLE
Add OBO and OBO Graph JSON exports

### DIFF
--- a/owl/README.md
+++ b/owl/README.md
@@ -1,0 +1,12 @@
+# CEMO
+
+Only edit `cemo.owl`.
+
+Run the following two commands using [ROBOT](http://robot.obolibrary.org/convert.html) to generate OBO text and OBO Graph JSON files.
+
+```bash
+robot convert -i cemo.owl -o cemo.obo --check=false
+robot convert -i cemo.owl -o cemo.json --check=false
+```
+
+TODO: better align with OBO standards so the `--check=false` can be removed.

--- a/owl/README.md
+++ b/owl/README.md
@@ -5,8 +5,8 @@ Only edit `cemo.owl`.
 Run the following two commands using [ROBOT](http://robot.obolibrary.org/convert.html) to generate OBO text and OBO Graph JSON files.
 
 ```bash
-robot convert -i cemo.owl -o cemo.obo --check=false
-robot convert -i cemo.owl -o cemo.json --check=false
+robot merge -i cemo.owl convert -o cemo.obo --check=false
+robot merge -i cemo.owl convert -o cemo.json --check=false
 ```
 
 TODO: better align with OBO standards so the `--check=false` can be removed.

--- a/owl/cemo.json
+++ b/owl/cemo.json
@@ -3,2485 +3,6 @@
     {
       "nodes": [
         {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000019",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Quality"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the shape of your nose"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the mass of this piece of gold."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the color of a tomato"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "quality"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the shape of your nostril"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the length of the circumference of your waist"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the ambient temperature of this portion of air"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "quality"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000015",
-          "meta": {
-            "definition": {
-              "val": "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "process"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a process of cell-division, \\ a beating of the heart"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the life of an organism"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the flight of a bird"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a process of meiosis"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Process"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a process of sleeping"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "your process of aging."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the course of a disease"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "process"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000016",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "disposition"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "certain people have a predisposition to colon cancer"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "children are innately disposed to categorize objects in certain ways."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an atom of element X has the disposition to decay to an atom of element Y"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Disposition"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "disposition"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000017",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "realizable"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "RealizableEntity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of being a doctor"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the disposition of your blood to coagulate"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the function of your reproductive organs"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the disposition of this piece of metal to conduct electricity."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of this boundary to delineate where Utah and Colorado meet"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "realizable entity"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000018",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A zero-dimensional spatial region is a point in space. (axiom label in BFO2 Reference: [037-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ZeroDimensionalSpatialRegion"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (ZeroDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [037-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "0d-s-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "zero-dimensional spatial region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000011",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every spatiotemporal region occupies_spatiotemporal_region itself."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every spatiotemporal region s is such that s occupies_spatiotemporal_region s. (axiom label in BFO2 Reference: [107-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x t) (if (SpatioTemporalRegion x) (exists (y) (and (SpatialRegion y) (spatiallyProjectsOntoAt x y t))))) // axiom label in BFO2 CLIF: [099-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (r) (if (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion r r))) // axiom label in BFO2 CLIF: [107-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the spatiotemporal region occupied by a process of cellular meiosis."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "st-region"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y) (if (and (SpatioTemporalRegion x) (occurrentPartOf y x)) (SpatioTemporalRegion y))) // axiom label in BFO2 CLIF: [096-001] "
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "All parts of spatiotemporal regions are spatiotemporal regions. (axiom label in BFO2 Reference: [096-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "SpatiotemporalRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (SpatioTemporalRegion x) (exists (y) (and (TemporalRegion y) (temporallyProjectsOnto x y))))) // axiom label in BFO2 CLIF: [098-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the spatiotemporal region occupied by a human life"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Each spatiotemporal region projects_onto some temporal region. (axiom label in BFO2 Reference: [098-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Each spatiotemporal region at any time t projects_onto some spatial region at t. (axiom label in BFO2 Reference: [099-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (SpatioTemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [095-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the spatiotemporal region occupied by the development of a cancer tumor"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "spatiotemporal region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000116",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "editor note"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000117",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "term editor"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000115",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "definition"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000179",
-          "meta": {
-            "definition": {
-              "val": "Relates an entity in the ontology to the name of the variable that is used to represent it in the code that generates the BFO OWL file from the lispy specification.",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
-                "val": "Really of interest to developers only"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "BFO OWL specification label"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000112",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "example of usage"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000111",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "editor preferred term"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000232",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "curator note"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000008",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (TemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [100-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (r) (if (TemporalRegion r) (occupiesTemporalRegion r r))) // axiom label in BFO2 CLIF: [119-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every temporal region t is such that t occupies_temporal_region t. (axiom label in BFO2 Reference: [119-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "TemporalRegion"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "t-region"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "All parts of temporal regions are temporal regions. (axiom label in BFO2 Reference: [101-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y) (if (and (TemporalRegion x) (occurrentPartOf y x)) (TemporalRegion y))) // axiom label in BFO2 CLIF: [101-001] "
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "temporal region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000009",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "TwoDimensionalSpatialRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A two-dimensional spatial region is a spatial region that is of two dimensions. (axiom label in BFO2 Reference: [039-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the surface of a sphere-shaped part of space"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (TwoDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [039-001] "
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an infinitely thin plane in space."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "2d-s-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "two-dimensional spatial region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000004",
-          "meta": {
-            "definition": {
-              "val": "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "For every independent continuant b and time t during the region of time spanned by its life, there are entities which s-depends_on b during t. (axiom label in BFO2 Reference: [018-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x t) (if (IndependentContinuant x) (exists (r) (and (SpatialRegion r) (locatedInAt x r t))))) // axiom label in BFO2 CLIF: [134-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an atom"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of your mouth"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a chair"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a spatial region"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the bottom right portion of a human torso"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "ic"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x t) (if (and (IndependentContinuant x) (existsAt x t)) (exists (y) (and (Entity y) (specificallyDependsOnAt y x t))))) // axiom label in BFO2 CLIF: [018-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "For any independent continuant b and any time t there is some spatial region r such that b is located_in r at t. (axiom label in BFO2 Reference: [134-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a leg"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "IndependentContinuant"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an organism"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a molecule"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an orchestra."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (IndependentContinuant a) (and (Continuant a) (not (exists (b t) (specificallyDependsOnAt a b t))))) // axiom label in BFO2 CLIF: [017-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a heart"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "independent continuant"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000118",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "alternative term"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000006",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Spatial regions do not participate in processes."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "SpatialRegion"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "s-region"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "spatial region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000119",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "definition source"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0010000",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "has axiom label"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000600",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "elucidation"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000001",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "Julius Caesar"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "Verdi’s Requiem"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Entity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "your body mass index"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "entity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the Second World War"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "entity"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000601",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "has associated axiom(nl)"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000002",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "continuant"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Continuant"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "continuant"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000003",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "occurrent"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Occurrent"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame."
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "occurrent"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000040",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a sea wave"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "material"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a tornado"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the undetached arm of a human being"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a puff of smoke"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an epidemic"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an aggregate of human beings."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a forest fire"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a hurricane"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "MaterialEntity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an energy wave"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a human being"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a flame"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a photon"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "material entity"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000038",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "OneDimensionalTemporalRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (OneDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [103-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the temporal region during which a process occurs."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "1d-t-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "one-dimensional temporal region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000602",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "has associated axiom(fol)"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000034",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the function of a hammer to drive in nails"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the function of amylase in saliva to break down starch into sugar"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "function"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the function of a heart pacemaker to regulate the beating of a heart through electricity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Function"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "function"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000035",
-          "meta": {
-            "definition": {
-              "val": "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (ProcessBoundary x) (exists (y) (and (ZeroDimensionalTemporalRegion y) (occupiesTemporalRegion x y))))) // axiom label in BFO2 CLIF: [085-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every process boundary occupies_temporal_region a zero-dimensional temporal region. (axiom label in BFO2 Reference: [085-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the boundary between the 2nd and 3rd year of your life."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (ProcessBoundary a) (exists (p) (and (Process p) (temporalPartOf a p) (not (exists (b) (properTemporalPartOf b a)))))) // axiom label in BFO2 CLIF: [084-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "p-boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ProcessBoundary"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "process boundary"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/IAO_0000412",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/iao.owl"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "imported from"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000030",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "planet"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "object"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "organism"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "star"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "cell"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Object"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "atom"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "molecule"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: an object is a maximal causally unified material entity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "solid portions of matter"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "cells and organisms"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "engineered artifacts"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "organelle"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "grain of sand"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "object"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000031",
-          "meta": {
-            "definition": {
-              "val": "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "gdc"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "GenericallyDependentContinuant"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "generically dependent continuant"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000026",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (OneDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [038-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an edge of a cube-shaped portion of space."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A one-dimensional spatial region is a line or aggregate of lines stretching from one point in space to another. (axiom label in BFO2 Reference: [038-001])"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "OneDimensionalSpatialRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "1d-s-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "one-dimensional spatial region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000147",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ZeroDimensionalContinuantFiatBoundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the geographic North Pole"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the point of origin of some spatial coordinate system."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "zero dimension continuant fiat boundaries are not spatial points. Considering the example 'the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet' : There are many frames in which that point is zooming through many points in space. Whereas, no matter what the frame, the quadripoint is always in the same relation to the boundaries of Colorado, Utah, New Mexico, and Arizona."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "a zero-dimensional continuant fiat boundary is a fiat point whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [031-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (ZeroDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (ZeroDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [031-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "0d-cf-boundary"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "zero-dimensional continuant fiat boundary"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000027",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a swarm of bees is an aggregate of members who are linked together through natural bonds"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "defined through physical attachment: the aggregate of atoms in a lump of granite"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a symphony orchestra"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "your collection of Meissen ceramic plates."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (ObjectAggregate x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y z) (and (Object y) (Object z) (memberPartOfAt y x t) (memberPartOfAt z x t) (not (= y z)))))) (not (exists (w t_1) (and (memberPartOfAt w x t_1) (not (Object w)))))))) // axiom label in BFO2 CLIF: [025-004] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "object-aggregate"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
-                "val": "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ObjectAggregate"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the restaurants in Palo Alto"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "defined by fiat: the aggregate of members of an organization"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a collection of cells in a blood biobank."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "defined via attributive delimitations such as: the patients in this hospital"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the nitrogen atoms in the atmosphere"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the aggregate of blood cells in your body"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the aggregate of bearings in a constant velocity axle joint"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "object aggregate"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000148",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (ZeroDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [102-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000118",
-                "val": "temporal instant."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ZeroDimensionalTemporalRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the moment at which a finger is detached in an industrial accident"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a temporal region that is occupied by a process boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the moment at which a child is born"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the moment of death."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "right now"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "0d-t-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "zero-dimensional temporal region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000028",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (ThreeDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [040-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a sphere-shaped region of space,"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ThreeDimensionalSpatialRegion"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A three-dimensional spatial region is a spatial region that is of three dimensions. (axiom label in BFO2 Reference: [040-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a cube-shaped region of space"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "3d-s-region"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "three-dimensional spatial region"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000029",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "an air traffic control region defined in the airspace above an airport"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the Grand Canyon"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the Piazza San Marco"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a rabbit hole"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "your left nostril (a fiat part – the opening – of your left nasal cavity)"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the hold of a ship"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the lumen of your gut"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "site"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a hole in the interior of a portion of cheese"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of a kangaroo pouch"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of the trunk of your car"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "Manhattan Canyon)"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the cockpit of an aircraft"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Site"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of your refrigerator"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of your office"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the interior of your bedroom"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "site"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000180",
-          "meta": {
-            "definition": {
-              "val": "Relates an entity in the ontology to the term that is used to represent it in the the CLIF specification of BFO2",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
-                "val": "Really of interest to developers only"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
-                "val": "Person:Alan Ruttenberg"
-              }
-            ]
-          },
-          "type": "PROPERTY",
-          "lbl": "BFO CLIF specification label"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000182",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "History"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "history"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "history"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000144",
-          "meta": {
-            "definition": {
-              "val": "b is a process_profile =Def. there is some process c such that b process_profile_of c (axiom label in BFO2 Reference: [093-002])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ProcessProfile"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b process_profile_of c holds when b proper_occurrent_part_of c& there is some proper_occurrent_part d of c which has no parts in common with b & is mutually dependent on b& is such that b, c and d occupy the same temporal region (axiom label in BFO2 Reference: [094-005])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "On a somewhat higher level of complexity are what we shall call rate process profiles, which are the targets of selective abstraction focused not on determinate quality magnitudes plotted over time, but rather on certain ratios between these magnitudes and elapsed times. A speed process profile, for example, is represented by a graph plotting against time the ratio of distance covered per unit of time. Since rates may change, and since such changes, too, may have rates of change, we have to deal here with a hierarchy of process profile universals at successive levels"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x y) (if (processProfileOf x y) (and (properContinuantPartOf x y) (exists (z t) (and (properOccurrentPartOf z y) (TemporalRegion t) (occupiesSpatioTemporalRegion x t) (occupiesSpatioTemporalRegion y t) (occupiesSpatioTemporalRegion z t) (not (exists (w) (and (occurrentPartOf w x) (occurrentPartOf w z))))))))) // axiom label in BFO2 CLIF: [094-005] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "The simplest type of process profiles are what we shall call ‘quality process profiles’, which are the process profiles which serve as the foci of the sort of selective abstraction that is involved when measurements are made of changes in single qualities, as illustrated, for example, by process profiles of mass, temperature, aortic pressure, and so on."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (ProcessProfile a) (exists (b) (and (Process b) (processProfileOf a b)))) // axiom label in BFO2 CLIF: [093-002] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "One important sub-family of rate process profiles is illustrated by the beat or frequency profiles of cyclical processes, illustrated by the 60 beats per minute beating process of John’s heart, or the 120 beats per minute drumming process involved in one of John’s performances in a rock band, and so on. Each such process includes what we shall call a beat process profile instance as part, a subtype of rate process profile in which the salient ratio is not distance covered but rather number of beat cycles per unit of time. Each beat process profile instance instantiates the determinable universal beat process profile. But it also instantiates multiple more specialized universals at lower levels of generality, selected from   rate process profilebeat process profileregular beat process profile3 bpm beat process profile4 bpm beat process profileirregular beat process profileincreasing beat process profileand so on.In the case of a regular beat process profile, a rate can be assigned in the simplest possible fashion by dividing the number of cycles by the length of the temporal region occupied by the beating process profile as a whole. Irregular process profiles of this sort, for example as identified in the clinic, or in the readings on an aircraft instrument panel, are often of diagnostic significance."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "process-profile"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "process profile"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000023",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of a building in serving as a military target"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] "
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of a stone in marking a property boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "Role"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the student role"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of subject in a clinical trial"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "role"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the priest role"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of a boundary to demarcate two neighboring administrative territories"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "role"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000145",
-          "meta": {
-            "definition": {
-              "val": "b is a relational quality = Def. for some independent continuants c, d and for some time t: b quality_of c at t & b quality_of d at t. (axiom label in BFO2 Reference: [057-001])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "r-quality"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "RelationalQuality"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (RelationalQuality a) (exists (b c t) (and (IndependentContinuant b) (IndependentContinuant c) (qualityOfAt a b t) (qualityOfAt a c t)))) // axiom label in BFO2 CLIF: [057-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "a marriage bond, an instance of requited love, an obligation between one person and another."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "relational quality"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000024",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Most examples of fiat object parts are associated with theoretically drawn divisions"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(forall (x) (if (FiatObjectPart x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y) (and (Object y) (properContinuantPartOfAt x y t)))))))) // axiom label in BFO2 CLIF: [027-004] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the upper and lower lobes of the left lung"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "FiatObjectPart"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "fiat-object-part"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the division of the brain into regions"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "b is a fiat object part = Def. b is a material entity which is such that for all times t, if b exists at t then there is some object c such that b proper continuant_part of  c at t and c is demarcated from the remainder of c by a two-dimensional continuant fiat boundary. (axiom label in BFO2 Reference: [027-004])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the division of the planet into hemispheres"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the Western hemisphere of the Earth"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the FMA:regional parts of an intact human body."
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the dorsal and ventral surfaces of the body"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "or with divisions drawn by cognitive subjects for practical reasons, such as the division of a cake (before slicing) into (what will become) slices (and thus member parts of an object aggregate). However, this does not mean that fiat object parts are dependent for their existence on divisions or delineations effected by cognitive subjects. If, for example, it is correct to conceive geological layers of the Earth as fiat object parts of the Earth, then even though these layers were first delineated in recent times, still existed long before such delineation and what holds of these layers (for example that the oldest layers are also the lowest layers) did not begin to hold because of our acts of delineation.Treatment of material entity in BFOExamples viewed by some as problematic cases for the trichotomy of fiat object part, object, and object aggregate include: a mussel on (and attached to) a rock, a slime mold, a pizza, a cloud, a galaxy, a railway train with engine and multiple carriages, a clonal stand of quaking aspen, a bacterial community (biofilm), a broken femur. Note that, as Aristotle already clearly recognized, such problematic cases – which lie at or near the penumbra of instances defined by the categories in question – need not invalidate these categories. The existence of grey objects does not prove that there are not objects which are black and objects which are white; the existence of mules does not prove that there are not objects which are donkeys and objects which are horses. It does, however, show that the examples in question need to be addressed carefully in order to show how they can be fitted into the proposed scheme, for example by recognizing additional subdivisions [29"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "fiat object part"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000146",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "a two-dimensional continuant fiat boundary (surface) is a self-connected fiat surface whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [033-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "TwoDimensionalContinuantFiatBoundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "2d-cf-boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (TwoDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (TwoDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [033-001] "
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "two-dimensional continuant fiat boundary"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000140",
-          "meta": {
-            "definition": {
-              "val": "b is a continuant fiat boundary = Def. b is an immaterial entity that is of zero, one or two dimensions and does not include a spatial region as part. (axiom label in BFO2 Reference: [029-001])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (ContinuantFiatBoundary a) (and (ImmaterialEntity a) (exists (b) (and (or (ZeroDimensionalSpatialRegion b) (OneDimensionalSpatialRegion b) (TwoDimensionalSpatialRegion b)) (forall (t) (locatedInAt a b t)))) (not (exists (c t) (and (SpatialRegion c) (continuantPartOfAt c a t)))))) // axiom label in BFO2 CLIF: [029-001] "
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: In BFO 1.1 the assumption was made that the external surface of a material entity such as a cell could be treated as if it were a boundary in the mathematical sense. The new document propounds the view that when we talk about external surfaces of material objects in this way then we are talking about something fiat. To be dealt with in a future version: fiat boundaries at different levels of granularity.More generally, the focus in discussion of boundaries in BFO 2.0 is now on fiat boundaries, which means: boundaries for which there is no assumption that they coincide with physical discontinuities. The ontology of boundaries becomes more closely allied with the ontology of regions."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "cf-boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
-                "val": "Every continuant fiat boundary is located at some spatial region at every time at which it exists"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ContinuantFiatBoundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: a continuant fiat boundary is a boundary of some material entity (for example: the plane separating the Northern and Southern hemispheres; the North Pole), or it is a boundary of some immaterial entity (for example of some portion of airspace). Three basic kinds of continuant fiat boundary can be distinguished (together with various combination kinds [29"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Continuant fiat boundary doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the mereological sum of two-dimensional continuant fiat boundary and a one dimensional continuant fiat boundary that doesn't overlap it. The situation is analogous to temporal and spatial regions."
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "continuant fiat boundary"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000020",
-          "meta": {
-            "definition": {
-              "val": "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])",
-              "xrefs": []
-            },
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "of one-sided specifically dependent continuants: the mass of this tomato"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the disposition of this fish to decay"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the mutual dependence of proton donors and acceptors in chemical reactions [79"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "SpecificallyDependentContinuant"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the role of being a doctor"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the pink color of a medium rare piece of grilled filet mignon at its center"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "sdc"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the smell of this portion of mozzarella"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the function of this heart: to pump blood"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the shape of this hole."
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "specifically dependent continuant"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000141",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "immaterial"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "ImmaterialEntity"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-                "val": "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "immaterial entity"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/BFO_0000142",
-          "meta": {
-            "basicPropertyValues": [
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
-                "val": "a one-dimensional continuant fiat boundary is a continuous fiat line whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [032-001])"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the median sulcus of your tongue"
-              },
-              {
-                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-                "val": "http://purl.obolibrary.org/obo/bfo.owl"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "all lines of latitude and longitude"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "The Equator"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "the line separating the outer surface of the mucosa of the lower lip from the outer surface of the skin of the chin."
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
-                "val": "all geopolitical boundaries"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
-                "val": "(iff (OneDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (OneDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [032-001] "
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
-                "val": "1d-cf-boundary"
-              },
-              {
-                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
-                "val": "OneDimensionalContinuantFiatBoundary"
-              }
-            ]
-          },
-          "type": "CLASS",
-          "lbl": "one-dimensional continuant fiat boundary"
-        }
-      ],
-      "edges": [
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000018",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000004",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000146",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000024",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000147",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000008",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000009",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000017",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000029",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000027",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000006",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000040",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000019",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000141",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000031",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000020",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000034",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000023",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000145",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000140",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000144",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000011",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000030",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000001",
-          "pred": "is_a",
-          "obj": "http://www.w3.org/2002/07/owl#Thing"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000038",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000035",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000148",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000142",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000026",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000002",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000003",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000015",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000028",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000016",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
-        }
-      ],
-      "id": "http://purl.obolibrary.org/obo/bfo.owl",
-      "meta": {
-        "subsets": [],
-        "xrefs": [],
-        "basicPropertyValues": [
-          {
-            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-            "val": "BFO 2 Reference: BFO does not claim to provide complete coverage of entities of all types. It seeks only to provide coverage of those entities studied by empirical science together with those entities which affect or are involved in human activities such as data processing and planning - coverage that is sufficiently broad to provide assistance to those engaged in building domain ontologies for purposes of data annotation."
-          },
-          {
-            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-            "val": "BFO 2 Reference: BFO's treatment of continuants and occurrents - as also its treatment of regions, rests on a dichotomy between space and time, and on the view that there are two perspectives on reality - earlier called the 'SNAP' and 'SPAN' perspectives, both of which are essential to the non-reductionist representation of reality as we understand it from the best available science."
-          },
-          {
-            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
-            "val": "BFO 2 Reference: For both terms and relational expressions in BFO, we distinguish between primitive and defined. 'Entity' is an example of a  primitive term. Primitive terms in a highest-level ontology such as BFO are terms that are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms."
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Alan Ruttenberg"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Albert Goldfain"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Barry Smith"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Bill Duncan"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Bjoern Peters"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Chris Mungall"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "David Osumi-Sutherland"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Fabian Neuhaus"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Holger Stenzhorn"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "James A. Overton"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Janna Hastings"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Jie Zheng"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Jonathan Bona"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Larry Hunter"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Leonard Jacuzzo"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Ludger Jansen"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Mark Ressler"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Mathias Brochhausen"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Mauricio Almeida"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Melanie Courtot"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Pierre Grenon"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Randall Dipert"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Ron Rudnicki"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Selja Seppälä"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Stefan Schulz"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Thomas Bittner"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Werner Ceusters"
-          },
-          {
-            "pred": "http://purl.org/dc/elements/1.1/contributor",
-            "val": "Yongqun \"Oliver\" He"
-          },
-          {
-            "pred": "http://purl.org/dc/terms/license",
-            "val": "http://creativecommons.org/licenses/by/4.0/"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
-            "val": "Please see the project site https://github.com/BFO-ontology/BFO, the bfo2 owl discussion group http://groups.google.com/group/bfo-owl-devel, the bfo2 discussion group http://groups.google.com/group/bfo-devel, the tracking google doc http://goo.gl/IlrEE, and the current version of the bfo2 reference http://purl.obolibrary.org/obo/bfo/dev/bfo2-reference.docx. This ontology is generated from a specification at https://github.com/BFO-ontology/BFO/tree/master/src/ontology/owl-group/specification/ and with the code that generates the OWL version in https://github.com/BFO-ontology/BFO/tree/master/src/tools/. A very early version of BFO version 2 in CLIF is at http://purl.obolibrary.org/obo/bfo/dev/bfo.clif."
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
-            "val": "The BSD license on the BFO project site refers to code used to build BFO."
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
-            "val": "This BFO 2.0 version represents a major update to BFO and is not strictly backwards compatible with BFO 1.1. The previous OWL version of BFO, version 1.1.1 will remain available at http://ifomis.org/bfo/1.1 and will no longer be updated. The BFO 2.0 OWL is a classes-only specification. The incorporation of core relations has been held over for a later version."
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-            "val": "http://purl.obolibrary.org/obo/bfo/dev/bfo.clif"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-            "val": "https://github.com/BFO-ontology/BFO/tree/master/src/ontology/owl-group/specification/"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-            "val": "http://groups.google.com/group/bfo-devel"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-            "val": "http://groups.google.com/group/bfo-discuss"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-            "val": "http://groups.google.com/group/bfo-owl-devel"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-            "val": "http://purl.obolibrary.org/obo/bfo/dev/owl"
-          },
-          {
-            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-            "val": "https://github.com/BFO-ontology/BFO/tree/master/src/tools/"
-          },
-          {
-            "pred": "http://xmlns.com/foaf/0.1/homepage",
-            "val": "http://basic-formal-ontology.org/"
-          },
-          {
-            "pred": "http://xmlns.com/foaf/0.1/homepage",
-            "val": "http://ifomis.org/bfo"
-          },
-          {
-            "pred": "http://xmlns.com/foaf/0.1/homepage",
-            "val": "https://github.com/BFO-ontology/BFO"
-          },
-          {
-            "pred": "http://xmlns.com/foaf/0.1/mbox",
-            "val": "mailto:bfo-owl-devel@googlegroups.com"
-          }
-        ],
-        "version": "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"
-      },
-      "equivalentNodesSets": [],
-      "logicalDefinitionAxioms": [],
-      "domainRangeAxioms": [],
-      "propertyChainAxioms": []
-    },
-    {
-      "nodes": [
-        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate",
           "meta": {
             "basicPropertyValues": [
@@ -2536,14 +57,14 @@
           "lbl": "time boundary of"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
-          "type": "CLASS",
-          "lbl": "non-pharmaceutical interventions"
-        },
-        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings",
           "type": "CLASS",
           "lbl": "percentage of laboratory findings"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
+          "type": "CLASS",
+          "lbl": "non-pharmaceutical interventions"
         },
         {
           "id": "http://purl.obolibrary.org/obo/IAO_0020000",
@@ -2605,6 +126,11 @@
           "lbl": "quarantine period"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
+          "type": "CLASS",
+          "lbl": "number of cases with missing exposure information"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000569",
           "meta": {
             "basicPropertyValues": [
@@ -2616,11 +142,6 @@
           },
           "type": "CLASS",
           "lbl": "total number of cases"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
-          "type": "CLASS",
-          "lbl": "number of cases with missing exposure information"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#odds_ratio_for_being_an_infected_contact",
@@ -2705,6 +226,19 @@
           "id": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_died",
           "type": "CLASS",
           "lbl": "median age of cases died"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000412",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "imported from"
         },
         {
           "id": "http://purl.obolibrary.org/obo/OBCS_0000064",
@@ -2820,6 +354,11 @@
           "lbl": "has quality"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates",
+          "type": "CLASS",
+          "lbl": "new daily case rates"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel",
           "type": "CLASS",
           "lbl": "proportion of cases attributed to travel"
@@ -2836,11 +375,6 @@
           },
           "type": "CLASS",
           "lbl": "incidence proportion"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates",
-          "type": "CLASS",
-          "lbl": "new daily case rates"
         },
         {
           "id": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
@@ -3008,6 +542,11 @@
           "lbl": "per capita mobility"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000424",
+          "type": "CLASS",
+          "lbl": "risk difference"
+        },
+        {
           "id": "http://www.onto-med.de/ontologies/gfo.owl#Time",
           "meta": {
             "basicPropertyValues": [
@@ -3019,11 +558,6 @@
           },
           "type": "CLASS",
           "lbl": "time"
-        },
-        {
-          "id": "http://purl.obolibrary.org/obo/STATO_0000424",
-          "type": "CLASS",
-          "lbl": "risk difference"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tests",
@@ -3087,19 +621,45 @@
           "lbl": "has participant"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000600",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "elucidation"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#infectious_process",
           "type": "CLASS",
           "lbl": "infectious process"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
-          "type": "CLASS",
-          "lbl": "number of cases exposed by local (one or cluster) case"
+          "id": "http://purl.obolibrary.org/obo/IAO_0000601",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has associated axiom(nl)"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_hospitalized",
           "type": "CLASS",
           "lbl": "median age of cases hospitalized"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
+          "type": "CLASS",
+          "lbl": "number of cases exposed by local (one or cluster) case"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_died",
@@ -3138,6 +698,19 @@
           "id": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure",
           "type": "CLASS",
           "lbl": "processual structure"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000602",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has associated axiom(fol)"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate",
@@ -3344,14 +917,14 @@
           "lbl": "cumulative case rates"
         },
         {
-          "id": "http://www.onto-med.de/ontologies/gfo.owl#has_left_time_boundary",
-          "type": "PROPERTY",
-          "lbl": "has left time boundary"
-        },
-        {
           "id": "http://www.onto-med.de/ontologies/gfo.owl#Concrete",
           "type": "CLASS",
           "lbl": "concrete"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#has_left_time_boundary",
+          "type": "PROPERTY",
+          "lbl": "has left time boundary"
         },
         {
           "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000163",
@@ -3372,9 +945,35 @@
           "lbl": "percentage of cases"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000116",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "editor note"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay",
           "type": "CLASS",
           "lbl": "length of icu stay"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000117",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "term editor"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#incidence_of_sever_outcomes",
@@ -3382,9 +981,78 @@
           "lbl": "incidence of sever outcomes"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000179",
+          "meta": {
+            "definition": {
+              "val": "Relates an entity in the ontology to the name of the variable that is used to represent it in the code that generates the BFO OWL file from the lispy specification.",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
+                "val": "Really of interest to developers only"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "BFO OWL specification label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000115",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "definition"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000112",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "example of usage"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected",
           "type": "CLASS",
           "lbl": "percentage of cases which are detected"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000111",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "editor preferred term"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000232",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "curator note"
         },
         {
           "id": "http://purl.obolibrary.org/obo/BFO_0000054",
@@ -3409,6 +1077,19 @@
           "lbl": "study group population size"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000118",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "alternative term"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate",
           "meta": {
             "basicPropertyValues": [
@@ -3420,6 +1101,19 @@
           },
           "type": "CLASS",
           "lbl": "reproductive rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000119",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "definition source"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts",
@@ -3460,6 +1154,111 @@
           "id": "http://purl.obolibrary.org/obo/IDO_0000665",
           "type": "CLASS",
           "lbl": "source of infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000040",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the undetached arm of a human being"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a puff of smoke"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an epidemic"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a forest fire"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a hurricane"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a flame"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a sea wave"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "material"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a tornado"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an aggregate of human beings."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "MaterialEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an energy wave"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a human being"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a photon"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "material entity"
         },
         {
           "id": "http://purl.obolibrary.org/obo/IAO_0000003",
@@ -3581,17 +1380,58 @@
           "lbl": "new daily cases"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#cases_by_exposure_in_a_healthcare_setting",
-          "type": "CLASS",
-          "lbl": "cases by exposure in a healthcare setting"
-        },
-        {
           "id": "http://purl.obolibrary.org/obo/RO_0002536",
           "type": "PROPERTY",
           "lbl": "has unit"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cases_by_exposure_in_a_healthcare_setting",
+          "type": "CLASS",
+          "lbl": "cases by exposure in a healthcare setting"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000180",
+          "meta": {
+            "definition": {
+              "val": "Relates an entity in the ontology to the term that is used to represent it in the the CLIF specification of BFO2",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
+                "val": "Really of interest to developers only"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
+                "val": "Person:Alan Ruttenberg"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "BFO CLIF specification label"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "History"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "history"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
           "type": "CLASS",
           "lbl": "natural history"
         },
@@ -3619,9 +1459,274 @@
           "lbl": "points of interest (pois)"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000019",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of your nose"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mass of this piece of gold."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the color of a tomato"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "quality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the length of the circumference of your waist"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the ambient temperature of this portion of air"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Quality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of your nostril"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "quality"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_hospital",
           "type": "CLASS",
           "lbl": "number of cases currently in hospital"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000015",
+          "meta": {
+            "definition": {
+              "val": "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the life of an organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the flight of a bird"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "process"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of cell-division, \\ a beating of the heart"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of meiosis"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Process"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of sleeping"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your process of aging."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the course of a disease"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000016",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "disposition"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "children are innately disposed to categorize objects in certain ways."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Disposition"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "certain people have a predisposition to colon cancer"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an atom of element X has the disposition to decay to an atom of element Y"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "disposition"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000017",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of your blood to coagulate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of this piece of metal to conduct electricity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "realizable"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "RealizableEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of being a doctor"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of your reproductive organs"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of this boundary to delineate where Utah and Colorado meet"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "realizable entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000018",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A zero-dimensional spatial region is a point in space. (axiom label in BFO2 Reference: [037-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ZeroDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [037-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional spatial region"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#distribution",
@@ -3683,6 +1788,83 @@
           "lbl": "at-risk population"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000011",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (SpatioTemporalRegion x) (exists (y) (and (SpatialRegion y) (spatiallyProjectsOntoAt x y t))))) // axiom label in BFO2 CLIF: [099-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (r) (if (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion r r))) // axiom label in BFO2 CLIF: [107-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by a process of cellular meiosis."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "st-region"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatioTemporalRegion x) (exists (y) (and (TemporalRegion y) (temporallyProjectsOnto x y))))) // axiom label in BFO2 CLIF: [098-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by a human life"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Each spatiotemporal region at any time t projects_onto some spatial region at t. (axiom label in BFO2 Reference: [099-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatioTemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [095-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by the development of a cancer tumor"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every spatiotemporal region occupies_spatiotemporal_region itself."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every spatiotemporal region s is such that s occupies_spatiotemporal_region s. (axiom label in BFO2 Reference: [107-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (SpatioTemporalRegion x) (occurrentPartOf y x)) (SpatioTemporalRegion y))) // axiom label in BFO2 CLIF: [096-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All parts of spatiotemporal regions are spatiotemporal regions. (axiom label in BFO2 Reference: [096-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpatiotemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Each spatiotemporal region projects_onto some temporal region. (axiom label in BFO2 Reference: [098-001])"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "spatiotemporal region"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#cluster_size",
           "meta": {
             "basicPropertyValues": [
@@ -3694,6 +1876,55 @@
           },
           "type": "CLASS",
           "lbl": "cluster size"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000008",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (TemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [100-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (r) (if (TemporalRegion r) (occupiesTemporalRegion r r))) // axiom label in BFO2 CLIF: [119-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every temporal region t is such that t occupies_temporal_region t. (axiom label in BFO2 Reference: [119-002])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (TemporalRegion x) (occurrentPartOf y x)) (TemporalRegion y))) // axiom label in BFO2 CLIF: [101-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "t-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All parts of temporal regions are temporal regions. (axiom label in BFO2 Reference: [101-001])"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "temporal region"
         },
         {
           "id": "http://purl.obolibrary.org/obo/COVOC_0010003",
@@ -3709,9 +1940,176 @@
           "lbl": "confirmed cases"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000009",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TwoDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A two-dimensional spatial region is a spatial region that is of two dimensions. (axiom label in BFO2 Reference: [039-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the surface of a sphere-shaped part of space"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (TwoDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [039-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an infinitely thin plane in space."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "2d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "two-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000004",
+          "meta": {
+            "definition": {
+              "val": "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a spatial region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the bottom right portion of a human torso"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "ic"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "For any independent continuant b and any time t there is some spatial region r such that b is located_in r at t. (axiom label in BFO2 Reference: [134-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a leg"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "IndependentContinuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an orchestra."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "For every independent continuant b and time t during the region of time spanned by its life, there are entities which s-depends_on b during t. (axiom label in BFO2 Reference: [018-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (IndependentContinuant x) (exists (r) (and (SpatialRegion r) (locatedInAt x r t))))) // axiom label in BFO2 CLIF: [134-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an atom"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your mouth"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a chair"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (and (IndependentContinuant x) (existsAt x t)) (exists (y) (and (Entity y) (specificallyDependsOnAt y x t))))) // axiom label in BFO2 CLIF: [018-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a molecule"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (IndependentContinuant a) (and (Continuant a) (not (exists (b t) (specificallyDependsOnAt a b t))))) // axiom label in BFO2 CLIF: [017-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a heart"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "independent continuant"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#onset_of_symptom_to_hospitalization",
           "type": "CLASS",
           "lbl": "onset of symptom to hospitalization"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000006",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Spatial regions do not participate in processes."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpatialRegion"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "s-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "spatial region"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#daily_cases",
@@ -3732,6 +2130,19 @@
           "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases",
           "type": "CLASS",
           "lbl": "cumulative cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0010000",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has axiom label"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters",
@@ -3778,9 +2189,176 @@
           "lbl": "susceptibility"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000001",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Julius Caesar"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Verdi’s Requiem"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your body mass index"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Second World War"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000002",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "continuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Continuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "continuant"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/IDO_0000586",
           "type": "CLASS",
           "lbl": "infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000003",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "occurrent"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Occurrent"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "occurrent"
         },
         {
           "id": "http://purl.obolibrary.org/obo/IDO_0000466",
@@ -3837,6 +2415,43 @@
           "lbl": "percentage cases female sex"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000038",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalTemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (OneDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [103-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the temporal region during which a process occurs."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-t-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional temporal region"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage",
           "meta": {
             "basicPropertyValues": [
@@ -3865,11 +2480,6 @@
           "lbl": "testing rate"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case",
-          "type": "CLASS",
-          "lbl": "initial exposed case"
-        },
-        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate",
           "meta": {
             "basicPropertyValues": [
@@ -3883,6 +2493,11 @@
           "lbl": "infection fatality rate"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case",
+          "type": "CLASS",
+          "lbl": "initial exposed case"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/has_confidence_level",
           "type": "PROPERTY",
           "lbl": "has confidence level"
@@ -3893,14 +2508,14 @@
           "lbl": "number of cases with school exposure events"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection",
-          "type": "CLASS",
-          "lbl": "duration of infection"
-        },
-        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_sars-cov-2_seropositivity",
           "type": "CLASS",
           "lbl": "prevalence of sars-cov-2 seropositivity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection",
+          "type": "CLASS",
+          "lbl": "duration of infection"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#host_risk_factor",
@@ -3913,6 +2528,92 @@
           "lbl": "number of cases with no symptoms"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000034",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "function"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of a hammer to drive in nails"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of amylase in saliva to break down starch into sugar"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of a heart pacemaker to regulate the beating of a heart through electricity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Function"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "function"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000035",
+          "meta": {
+            "definition": {
+              "val": "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ProcessBoundary x) (exists (y) (and (ZeroDimensionalTemporalRegion y) (occupiesTemporalRegion x y))))) // axiom label in BFO2 CLIF: [085-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ProcessBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every process boundary occupies_temporal_region a zero-dimensional temporal region. (axiom label in BFO2 Reference: [085-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the boundary between the 2nd and 3rd year of your life."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ProcessBoundary a) (exists (p) (and (Process p) (temporalPartOf a p) (not (exists (b) (properTemporalPartOf b a)))))) // axiom label in BFO2 CLIF: [084-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "p-boundary"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "process boundary"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts",
           "type": "CLASS",
           "lbl": "average rate of infectious contacts"
@@ -3921,6 +2622,136 @@
           "id": "http://purl.obolibrary.org/obo/STATO_0000129",
           "type": "PROPERTY",
           "lbl": "has value"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000030",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "planet"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "object"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Object"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "atom"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "molecule"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "engineered artifacts"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "organelle"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "grain of sand"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "star"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "cell"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: an object is a maximal causally unified material entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "solid portions of matter"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "cells and organisms"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "object"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000031",
+          "meta": {
+            "definition": {
+              "val": "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "gdc"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "GenericallyDependentContinuant"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "generically dependent continuant"
         },
         {
           "id": "http://purl.obolibrary.org/obo/IDO_0000458",
@@ -3938,9 +2769,363 @@
           "lbl": "denotes"
         },
         {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000147",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the geographic North Pole"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the point of origin of some spatial coordinate system."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "zero dimension continuant fiat boundaries are not spatial points. Considering the example 'the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet' : There are many frames in which that point is zooming through many points in space. Whereas, no matter what the frame, the quadripoint is always in the same relation to the boundaries of Colorado, Utah, New Mexico, and Arizona."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a zero-dimensional continuant fiat boundary is a fiat point whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [031-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ZeroDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (ZeroDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [031-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000026",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an edge of a cube-shaped portion of space."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A one-dimensional spatial region is a line or aggregate of lines stretching from one point in space to another. (axiom label in BFO2 Reference: [038-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-s-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (OneDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [038-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalSpatialRegion"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000027",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a swarm of bees is an aggregate of members who are linked together through natural bonds"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined through physical attachment: the aggregate of atoms in a lump of granite"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a symphony orchestra"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your collection of Meissen ceramic plates."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ObjectAggregate x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y z) (and (Object y) (Object z) (memberPartOfAt y x t) (memberPartOfAt z x t) (not (= y z)))))) (not (exists (w t_1) (and (memberPartOfAt w x t_1) (not (Object w)))))))) // axiom label in BFO2 CLIF: [025-004] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined by fiat: the aggregate of members of an organization"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined via attributive delimitations such as: the patients in this hospital"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the aggregate of blood cells in your body"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the aggregate of bearings in a constant velocity axle joint"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "object-aggregate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
+                "val": "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ObjectAggregate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the restaurants in Palo Alto"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a collection of cells in a blood biobank."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the nitrogen atoms in the atmosphere"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "object aggregate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000148",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ZeroDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [102-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000118",
+                "val": "temporal instant."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalTemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment at which a finger is detached in an industrial accident"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a temporal region that is occupied by a process boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment at which a child is born"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment of death."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "right now"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-t-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional temporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000028",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ThreeDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [040-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a cube-shaped region of space"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a sphere-shaped region of space,"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ThreeDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A three-dimensional spatial region is a spatial region that is of three dimensions. (axiom label in BFO2 Reference: [040-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "3d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "three-dimensional spatial region"
+        },
+        {
           "id": "http://purl.obolibrary.org/obo/OBI_0000011",
           "type": "CLASS",
           "lbl": "planned process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000029",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Piazza San Marco"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the lumen of your gut"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Manhattan Canyon)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your office"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your bedroom"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an air traffic control region defined in the airspace above an airport"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Grand Canyon"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a rabbit hole"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your left nostril (a fiat part – the opening – of your left nasal cavity)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the hold of a ship"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "site"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a hole in the interior of a portion of cheese"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of a kangaroo pouch"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of the trunk of your car"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the cockpit of an aircraft"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Site"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your refrigerator"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "site"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt",
@@ -3984,14 +3169,447 @@
           "lbl": "process"
         },
         {
-          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
+          "id": "http://purl.obolibrary.org/obo/BFO_0000144",
+          "meta": {
+            "definition": {
+              "val": "b is a process_profile =Def. there is some process c such that b process_profile_of c (axiom label in BFO2 Reference: [093-002])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ProcessProfile"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "On a somewhat higher level of complexity are what we shall call rate process profiles, which are the targets of selective abstraction focused not on determinate quality magnitudes plotted over time, but rather on certain ratios between these magnitudes and elapsed times. A speed process profile, for example, is represented by a graph plotting against time the ratio of distance covered per unit of time. Since rates may change, and since such changes, too, may have rates of change, we have to deal here with a hierarchy of process profile universals at successive levels"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (processProfileOf x y) (and (properContinuantPartOf x y) (exists (z t) (and (properOccurrentPartOf z y) (TemporalRegion t) (occupiesSpatioTemporalRegion x t) (occupiesSpatioTemporalRegion y t) (occupiesSpatioTemporalRegion z t) (not (exists (w) (and (occurrentPartOf w x) (occurrentPartOf w z))))))))) // axiom label in BFO2 CLIF: [094-005] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ProcessProfile a) (exists (b) (and (Process b) (processProfileOf a b)))) // axiom label in BFO2 CLIF: [093-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "process-profile"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b process_profile_of c holds when b proper_occurrent_part_of c& there is some proper_occurrent_part d of c which has no parts in common with b & is mutually dependent on b& is such that b, c and d occupy the same temporal region (axiom label in BFO2 Reference: [094-005])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The simplest type of process profiles are what we shall call ‘quality process profiles’, which are the process profiles which serve as the foci of the sort of selective abstraction that is involved when measurements are made of changes in single qualities, as illustrated, for example, by process profiles of mass, temperature, aortic pressure, and so on."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "One important sub-family of rate process profiles is illustrated by the beat or frequency profiles of cyclical processes, illustrated by the 60 beats per minute beating process of John’s heart, or the 120 beats per minute drumming process involved in one of John’s performances in a rock band, and so on. Each such process includes what we shall call a beat process profile instance as part, a subtype of rate process profile in which the salient ratio is not distance covered but rather number of beat cycles per unit of time. Each beat process profile instance instantiates the determinable universal beat process profile. But it also instantiates multiple more specialized universals at lower levels of generality, selected from   rate process profilebeat process profileregular beat process profile3 bpm beat process profile4 bpm beat process profileirregular beat process profileincreasing beat process profileand so on.In the case of a regular beat process profile, a rate can be assigned in the simplest possible fashion by dividing the number of cycles by the length of the temporal region occupied by the beating process profile as a whole. Irregular process profiles of this sort, for example as identified in the clinic, or in the readings on an aircraft instrument panel, are often of diagnostic significance."
+              }
+            ]
+          },
           "type": "CLASS",
-          "lbl": "number of cases exposed by local unknown exposure"
+          "lbl": "process profile"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000023",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a stone in marking a property boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the student role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a building in serving as a military target"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of subject in a clinical trial"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the priest role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a boundary to demarcate two neighboring administrative territories"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "role"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000145",
+          "meta": {
+            "definition": {
+              "val": "b is a relational quality = Def. for some independent continuants c, d and for some time t: b quality_of c at t & b quality_of d at t. (axiom label in BFO2 Reference: [057-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "r-quality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "RelationalQuality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (RelationalQuality a) (exists (b c t) (and (IndependentContinuant b) (IndependentContinuant c) (qualityOfAt a b t) (qualityOfAt a c t)))) // axiom label in BFO2 CLIF: [057-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a marriage bond, an instance of requited love, an obligation between one person and another."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "relational quality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000024",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "fiat-object-part"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a fiat object part = Def. b is a material entity which is such that for all times t, if b exists at t then there is some object c such that b proper continuant_part of  c at t and c is demarcated from the remainder of c by a two-dimensional continuant fiat boundary. (axiom label in BFO2 Reference: [027-004])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the division of the planet into hemispheres"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Western hemisphere of the Earth"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the dorsal and ventral surfaces of the body"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Most examples of fiat object parts are associated with theoretically drawn divisions"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (FiatObjectPart x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y) (and (Object y) (properContinuantPartOfAt x y t)))))))) // axiom label in BFO2 CLIF: [027-004] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the upper and lower lobes of the left lung"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "FiatObjectPart"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the division of the brain into regions"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the FMA:regional parts of an intact human body."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "or with divisions drawn by cognitive subjects for practical reasons, such as the division of a cake (before slicing) into (what will become) slices (and thus member parts of an object aggregate). However, this does not mean that fiat object parts are dependent for their existence on divisions or delineations effected by cognitive subjects. If, for example, it is correct to conceive geological layers of the Earth as fiat object parts of the Earth, then even though these layers were first delineated in recent times, still existed long before such delineation and what holds of these layers (for example that the oldest layers are also the lowest layers) did not begin to hold because of our acts of delineation.Treatment of material entity in BFOExamples viewed by some as problematic cases for the trichotomy of fiat object part, object, and object aggregate include: a mussel on (and attached to) a rock, a slime mold, a pizza, a cloud, a galaxy, a railway train with engine and multiple carriages, a clonal stand of quaking aspen, a bacterial community (biofilm), a broken femur. Note that, as Aristotle already clearly recognized, such problematic cases – which lie at or near the penumbra of instances defined by the categories in question – need not invalidate these categories. The existence of grey objects does not prove that there are not objects which are black and objects which are white; the existence of mules does not prove that there are not objects which are donkeys and objects which are horses. It does, however, show that the examples in question need to be addressed carefully in order to show how they can be fitted into the proposed scheme, for example by recognizing additional subdivisions [29"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "fiat object part"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000146",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a two-dimensional continuant fiat boundary (surface) is a self-connected fiat surface whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [033-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "2d-cf-boundary"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TwoDimensionalContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (TwoDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (TwoDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [033-001] "
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "two-dimensional continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000140",
+          "meta": {
+            "definition": {
+              "val": "b is a continuant fiat boundary = Def. b is an immaterial entity that is of zero, one or two dimensions and does not include a spatial region as part. (axiom label in BFO2 Reference: [029-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every continuant fiat boundary is located at some spatial region at every time at which it exists"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: a continuant fiat boundary is a boundary of some material entity (for example: the plane separating the Northern and Southern hemispheres; the North Pole), or it is a boundary of some immaterial entity (for example of some portion of airspace). Three basic kinds of continuant fiat boundary can be distinguished (together with various combination kinds [29"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Continuant fiat boundary doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the mereological sum of two-dimensional continuant fiat boundary and a one dimensional continuant fiat boundary that doesn't overlap it. The situation is analogous to temporal and spatial regions."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ContinuantFiatBoundary a) (and (ImmaterialEntity a) (exists (b) (and (or (ZeroDimensionalSpatialRegion b) (OneDimensionalSpatialRegion b) (TwoDimensionalSpatialRegion b)) (forall (t) (locatedInAt a b t)))) (not (exists (c t) (and (SpatialRegion c) (continuantPartOfAt c a t)))))) // axiom label in BFO2 CLIF: [029-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In BFO 1.1 the assumption was made that the external surface of a material entity such as a cell could be treated as if it were a boundary in the mathematical sense. The new document propounds the view that when we talk about external surfaces of material objects in this way then we are talking about something fiat. To be dealt with in a future version: fiat boundaries at different levels of granularity.More generally, the focus in discussion of boundaries in BFO 2.0 is now on fiat boundaries, which means: boundaries for which there is no assumption that they coincide with physical discontinuities. The ontology of boundaries becomes more closely allied with the ontology of regions."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000020",
+          "meta": {
+            "definition": {
+              "val": "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "of one-sided specifically dependent continuants: the mass of this tomato"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of this fish to decay"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the pink color of a medium rare piece of grilled filet mignon at its center"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the smell of this portion of mozzarella"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of this heart: to pump blood"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of this hole."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mutual dependence of proton donors and acceptors in chemical reactions [79"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpecificallyDependentContinuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of being a doctor"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "sdc"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "specifically dependent continuant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000141",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ImmaterialEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "immaterial"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "immaterial entity"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_removed_from_isolation",
           "type": "CLASS",
           "lbl": "total number of cases removed from isolation"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
+          "type": "CLASS",
+          "lbl": "number of cases exposed by local unknown exposure"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000142",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the median sulcus of your tongue"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "all lines of latitude and longitude"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The Equator"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a one-dimensional continuant fiat boundary is a continuous fiat line whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [032-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the line separating the outer surface of the mucosa of the lower lip from the outer surface of the skin of the chin."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "all geopolitical boundaries"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (OneDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (OneDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [032-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalContinuantFiatBoundary"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional continuant fiat boundary"
         },
         {
           "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates",
@@ -4001,54 +3619,14 @@
       ],
       "edges": [
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#etiology",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000018",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_female_sex",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposure",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#incidence_of_sever_outcomes",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/OBI_0000181",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#complication_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quarantined_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Concrete"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#environmental_risk_factor",
@@ -4066,22 +3644,7 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/NCIT_C164332",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/NCIT_C164607",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.ebi.ac.uk/efo/EFO_0004804",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4096,29 +3659,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/GSSO_006827",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000088",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000484",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/IAO_0000009",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space_time",
@@ -4126,39 +3669,14 @@
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#Individual"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/NCIT_C17734",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000146",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cluster_size",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/OBCS_0000064",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/NCBITaxon_2759"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/OGMS_0000031",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality",
@@ -4176,11 +3694,6 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/IAO_0000109",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts"
@@ -4189,11 +3702,6 @@
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts",
@@ -4206,19 +3714,9 @@
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#Space_time"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000482",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000009",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000414",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#line_of_infection",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_hospitalized_this_week",
@@ -4226,24 +3724,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#odds_ratio_for_being_an_infected_contact",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_died",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000296",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#untraceable_contacts",
@@ -4271,11 +3754,6 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/IAO_0000027",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
@@ -4286,19 +3764,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000658",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#exposure"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/IAO_0000030",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/BFO_0000031"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/OBI_0000181",
@@ -4306,17 +3774,7 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_hospital",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_mild_symptoms",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4331,24 +3789,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/NCIT_C67448",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#cases_by_exposure_in_a_healthcare_setting",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
         },
         {
           "sub": "http://purl.unep.org/sdg/SDGIO_00020030",
@@ -4361,9 +3804,19 @@
           "obj": "http://purl.obolibrary.org/obo/BFO_0000027"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000027",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000006",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000040",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
@@ -4386,26 +3839,6 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#growth_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_ever_hospitalized",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#health_systems_indicators",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators"
@@ -4416,32 +3849,7 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_2759",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/OBI_0100026"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/VO_0000247",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/IDO_0000519",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/COVOC_0010003",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4449,21 +3857,6 @@
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_icu",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_sars-cov-2_seropositivity",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Process",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_community_transmission",
@@ -4491,11 +3884,6 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000449",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
@@ -4506,34 +3894,9 @@
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposition_interval",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000141",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#testing_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000163",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_comorbidities_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing",
@@ -4551,24 +3914,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators"
         },
         {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary",
-          "pred": "is_a",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
-        },
-        {
           "sub": "http://www.onto-med.de/ontologies/gfo.owl#Concrete",
           "pred": "is_a",
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#Individual"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#hospitalization_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://www.onto-med.de/ontologies/gfo.owl#has_right_time_boundary",
@@ -4581,11 +3929,6 @@
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000569",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/OBI_0100026",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
@@ -4596,27 +3939,12 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_hospitalized",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#opportunity",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4651,16 +3979,6 @@
           "obj": "http://www.onto-med.de/ontologies/gfo.owl#Space_time"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#suspected_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#serial_interval",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/STATO_0000233",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
@@ -4671,32 +3989,7 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_removed",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#protection_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000466",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.orpha.net/ORDO/Orphanet_409966",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4704,21 +3997,6 @@
           "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#daily_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000245",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#service_coverage_indicators",
@@ -4741,19 +4019,14 @@
           "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#interpretation",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000134",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000140",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/IDO_0000665",
@@ -4766,9 +4039,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/RO_0002463",
-          "pred": "subPropertyOf",
-          "obj": "http://www.w3.org/2002/07/owl#topObjectProperty"
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000144",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#points_of_interest",
@@ -4776,24 +4049,14 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/OGMS_0000063",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000030",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_removed_from_isolation_this_week",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000001",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000182",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+          "obj": "http://www.w3.org/2002/07/owl#Thing"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate",
@@ -4801,17 +4064,12 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000038",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#herd_immunity_threshold",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/VIDO_0001331",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4824,26 +4082,6 @@
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#infectious_process",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_active_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000425",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000196",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/OAE_0001869",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/STATO_0000203",
@@ -4861,27 +4099,17 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/IAO_0000219",
-          "pred": "subPropertyOf",
-          "obj": "http://purl.obolibrary.org/obo/IAO_0000136"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_died",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence",
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000142",
           "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#susceptible_individuals",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/STATO_0000412",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4906,19 +4134,9 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_individuals",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000497",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/IDO_0000458",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection",
@@ -4931,17 +4149,622 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_icu",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#onset_of_symptom_to_hospitalization",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000067",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000023"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_no_symptoms",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
+          "pred": "subPropertyOf",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000009"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000011",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000002",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#etiology",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_female_sex",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposure",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#incidence_of_sever_outcomes",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#complication_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quarantined_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000004",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Concrete"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C164607",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.ebi.ac.uk/efo/EFO_0004804",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/GSSO_006827",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000088",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000484",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cluster_size",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C17734",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBCS_0000064",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/NCBITaxon_2759"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000024",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000109",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000147",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000008",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000482",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000414",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#line_of_infection",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#odds_ratio_for_being_an_infected_contact",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000296",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000017",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000658",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#exposure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_mild_symptoms",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C67448",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000029",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000019",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#growth_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_ever_hospitalized",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_2759",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/OBI_0100026"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/VO_0000247",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/COVOC_0010003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_sars-cov-2_seropositivity",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Process",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposition_interval",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#testing_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000163",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_comorbidities_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000031",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#hospitalization_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000569",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_hospitalized",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000020",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000034",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#suspected_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#serial_interval",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000023",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_removed",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#protection_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000145",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000466",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.orpha.net/ORDO/Orphanet_409966",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#daily_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000245",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#interpretation",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000134",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/RO_0002463",
+          "pred": "subPropertyOf",
+          "obj": "http://www.w3.org/2002/07/owl#topObjectProperty"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OGMS_0000063",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000011",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_removed_from_isolation_this_week",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/VIDO_0001331",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000035",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_active_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000425",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000196",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000148",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OAE_0001869",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000219",
+          "pred": "subPropertyOf",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000136"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000026",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000412",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000002",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_individuals",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000458",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_icu",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -4959,31 +4782,6 @@
           "sub": "http://purl.obolibrary.org/obo/IDO_0000511",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_no_symptoms",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/OBI_0000067",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000023"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
-          "pred": "subPropertyOf",
-          "obj": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#male-to-female_ratio",
@@ -5011,11 +4809,6 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/IAO_0000003",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/IAO_0000009"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/IDO_0000586",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
@@ -5031,14 +4824,24 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/OBI_0000011",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#attack_rate",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000015",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000028",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000016",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
         },
         {
           "sub": "http://purl.obolibrary.org/obo/IDO_0001343",
@@ -5046,17 +4849,7 @@
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
         {
-          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
           "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected",
-          "pred": "is_a",
-          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
-        },
-        {
-          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000002",
           "pred": "is_a",
           "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
         },
@@ -5139,14 +4932,14 @@
         },
         {
           "nodeIds": [
-            "http://purl.obolibrary.org/obo/OBI_0000181",
-            "http://purl.obolibrary.org/obo/IDO_0000509"
+            "http://purl.obolibrary.org/obo/BFO_0000035",
+            "http://www.onto-med.de/ontologies/gfo.owl#Event"
           ]
         },
         {
           "nodeIds": [
-            "http://purl.obolibrary.org/obo/BFO_0000035",
-            "http://www.onto-med.de/ontologies/gfo.owl#Event"
+            "http://purl.obolibrary.org/obo/OBI_0000181",
+            "http://purl.obolibrary.org/obo/IDO_0000509"
           ]
         }
       ],
@@ -5193,18 +4986,18 @@
           ]
         },
         {
+          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#projects_to",
+          "rangeClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Time"
+          ]
+        },
+        {
           "predicateId": "http://purl.obolibrary.org/obo/RO_0000059",
           "domainClassIds": [
             "http://purl.obolibrary.org/obo/BFO_0000020"
           ],
           "rangeClassIds": [
             "http://purl.obolibrary.org/obo/BFO_0000031"
-          ]
-        },
-        {
-          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#projects_to",
-          "rangeClassIds": [
-            "http://www.onto-med.de/ontologies/gfo.owl#Time"
           ]
         },
         {

--- a/owl/cemo.json
+++ b/owl/cemo.json
@@ -1,0 +1,5277 @@
+{
+  "graphs": [
+    {
+      "nodes": [
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000019",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Quality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of your nose"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mass of this piece of gold."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the color of a tomato"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "quality"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of your nostril"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the length of the circumference of your waist"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the ambient temperature of this portion of air"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "quality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000015",
+          "meta": {
+            "definition": {
+              "val": "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "process"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of cell-division, \\ a beating of the heart"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the life of an organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the flight of a bird"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of meiosis"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Process"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a process of sleeping"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your process of aging."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the course of a disease"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000016",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "disposition"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "certain people have a predisposition to colon cancer"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "children are innately disposed to categorize objects in certain ways."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an atom of element X has the disposition to decay to an atom of element Y"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Disposition"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "disposition"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000017",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "realizable"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "RealizableEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of being a doctor"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of your blood to coagulate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of your reproductive organs"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of this piece of metal to conduct electricity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of this boundary to delineate where Utah and Colorado meet"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "realizable entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000018",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A zero-dimensional spatial region is a point in space. (axiom label in BFO2 Reference: [037-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ZeroDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [037-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000011",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every spatiotemporal region occupies_spatiotemporal_region itself."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every spatiotemporal region s is such that s occupies_spatiotemporal_region s. (axiom label in BFO2 Reference: [107-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (SpatioTemporalRegion x) (exists (y) (and (SpatialRegion y) (spatiallyProjectsOntoAt x y t))))) // axiom label in BFO2 CLIF: [099-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (r) (if (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion r r))) // axiom label in BFO2 CLIF: [107-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by a process of cellular meiosis."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "st-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (SpatioTemporalRegion x) (occurrentPartOf y x)) (SpatioTemporalRegion y))) // axiom label in BFO2 CLIF: [096-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All parts of spatiotemporal regions are spatiotemporal regions. (axiom label in BFO2 Reference: [096-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpatiotemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatioTemporalRegion x) (exists (y) (and (TemporalRegion y) (temporallyProjectsOnto x y))))) // axiom label in BFO2 CLIF: [098-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by a human life"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Each spatiotemporal region projects_onto some temporal region. (axiom label in BFO2 Reference: [098-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Each spatiotemporal region at any time t projects_onto some spatial region at t. (axiom label in BFO2 Reference: [099-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatioTemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [095-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the spatiotemporal region occupied by the development of a cancer tumor"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "spatiotemporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000116",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "editor note"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000117",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "term editor"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000115",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "definition"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000179",
+          "meta": {
+            "definition": {
+              "val": "Relates an entity in the ontology to the name of the variable that is used to represent it in the code that generates the BFO OWL file from the lispy specification.",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
+                "val": "Really of interest to developers only"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "BFO OWL specification label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000112",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "example of usage"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000111",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "editor preferred term"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000232",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "curator note"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000008",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (TemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [100-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (r) (if (TemporalRegion r) (occupiesTemporalRegion r r))) // axiom label in BFO2 CLIF: [119-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every temporal region t is such that t occupies_temporal_region t. (axiom label in BFO2 Reference: [119-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TemporalRegion"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "t-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All parts of temporal regions are temporal regions. (axiom label in BFO2 Reference: [101-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (TemporalRegion x) (occurrentPartOf y x)) (TemporalRegion y))) // axiom label in BFO2 CLIF: [101-001] "
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "temporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000009",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TwoDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A two-dimensional spatial region is a spatial region that is of two dimensions. (axiom label in BFO2 Reference: [039-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the surface of a sphere-shaped part of space"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (TwoDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [039-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an infinitely thin plane in space."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "2d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "two-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000004",
+          "meta": {
+            "definition": {
+              "val": "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "For every independent continuant b and time t during the region of time spanned by its life, there are entities which s-depends_on b during t. (axiom label in BFO2 Reference: [018-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (IndependentContinuant x) (exists (r) (and (SpatialRegion r) (locatedInAt x r t))))) // axiom label in BFO2 CLIF: [134-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an atom"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your mouth"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a chair"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a spatial region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the bottom right portion of a human torso"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "ic"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x t) (if (and (IndependentContinuant x) (existsAt x t)) (exists (y) (and (Entity y) (specificallyDependsOnAt y x t))))) // axiom label in BFO2 CLIF: [018-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "For any independent continuant b and any time t there is some spatial region r such that b is located_in r at t. (axiom label in BFO2 Reference: [134-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a leg"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "IndependentContinuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a molecule"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an orchestra."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (IndependentContinuant a) (and (Continuant a) (not (exists (b t) (specificallyDependsOnAt a b t))))) // axiom label in BFO2 CLIF: [017-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a heart"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "independent continuant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000118",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "alternative term"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000006",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Spatial regions do not participate in processes."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpatialRegion"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "s-region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000119",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "definition source"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0010000",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has axiom label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000600",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "elucidation"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000001",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Julius Caesar"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Verdi’s Requiem"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your body mass index"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Second World War"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000601",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has associated axiom(nl)"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000002",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "continuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Continuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "continuant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000003",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "occurrent"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Occurrent"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "occurrent"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000040",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a sea wave"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "material"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a tornado"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the undetached arm of a human being"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a puff of smoke"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an epidemic"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an aggregate of human beings."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a forest fire"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a hurricane"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "MaterialEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an energy wave"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a human being"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a flame"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a photon"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "material entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000038",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalTemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (OneDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [103-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the temporal region during which a process occurs."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-t-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional temporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000602",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "has associated axiom(fol)"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000034",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of a hammer to drive in nails"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of amylase in saliva to break down starch into sugar"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "function"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of a heart pacemaker to regulate the beating of a heart through electricity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Function"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "function"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000035",
+          "meta": {
+            "definition": {
+              "val": "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ProcessBoundary x) (exists (y) (and (ZeroDimensionalTemporalRegion y) (occupiesTemporalRegion x y))))) // axiom label in BFO2 CLIF: [085-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every process boundary occupies_temporal_region a zero-dimensional temporal region. (axiom label in BFO2 Reference: [085-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the boundary between the 2nd and 3rd year of your life."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ProcessBoundary a) (exists (p) (and (Process p) (temporalPartOf a p) (not (exists (b) (properTemporalPartOf b a)))))) // axiom label in BFO2 CLIF: [084-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "p-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ProcessBoundary"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "process boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000412",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/iao.owl"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "imported from"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000030",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "planet"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "object"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "organism"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "star"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "cell"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Object"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "atom"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "molecule"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: an object is a maximal causally unified material entity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "solid portions of matter"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "cells and organisms"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "engineered artifacts"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "organelle"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "grain of sand"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "object"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000031",
+          "meta": {
+            "definition": {
+              "val": "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "gdc"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "GenericallyDependentContinuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "generically dependent continuant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000026",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (OneDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [038-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an edge of a cube-shaped portion of space."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A one-dimensional spatial region is a line or aggregate of lines stretching from one point in space to another. (axiom label in BFO2 Reference: [038-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000147",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the geographic North Pole"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the point of origin of some spatial coordinate system."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "zero dimension continuant fiat boundaries are not spatial points. Considering the example 'the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet' : There are many frames in which that point is zooming through many points in space. Whereas, no matter what the frame, the quadripoint is always in the same relation to the boundaries of Colorado, Utah, New Mexico, and Arizona."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a zero-dimensional continuant fiat boundary is a fiat point whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [031-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ZeroDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (ZeroDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [031-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-cf-boundary"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000027",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a swarm of bees is an aggregate of members who are linked together through natural bonds"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined through physical attachment: the aggregate of atoms in a lump of granite"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a symphony orchestra"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your collection of Meissen ceramic plates."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ObjectAggregate x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y z) (and (Object y) (Object z) (memberPartOfAt y x t) (memberPartOfAt z x t) (not (= y z)))))) (not (exists (w t_1) (and (memberPartOfAt w x t_1) (not (Object w)))))))) // axiom label in BFO2 CLIF: [025-004] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "object-aggregate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
+                "val": "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ObjectAggregate"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the restaurants in Palo Alto"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined by fiat: the aggregate of members of an organization"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a collection of cells in a blood biobank."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "defined via attributive delimitations such as: the patients in this hospital"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the nitrogen atoms in the atmosphere"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the aggregate of blood cells in your body"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the aggregate of bearings in a constant velocity axle joint"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "object aggregate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000148",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ZeroDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [102-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000118",
+                "val": "temporal instant."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ZeroDimensionalTemporalRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment at which a finger is detached in an industrial accident"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a temporal region that is occupied by a process boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment at which a child is born"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the moment of death."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "right now"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "0d-t-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "zero-dimensional temporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000028",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (ThreeDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [040-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a sphere-shaped region of space,"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ThreeDimensionalSpatialRegion"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A three-dimensional spatial region is a spatial region that is of three dimensions. (axiom label in BFO2 Reference: [040-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a cube-shaped region of space"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "3d-s-region"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "three-dimensional spatial region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000029",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "an air traffic control region defined in the airspace above an airport"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Grand Canyon"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Piazza San Marco"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a rabbit hole"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "your left nostril (a fiat part – the opening – of your left nasal cavity)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the hold of a ship"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the lumen of your gut"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "site"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a hole in the interior of a portion of cheese"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of a kangaroo pouch"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of the trunk of your car"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Manhattan Canyon)"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the cockpit of an aircraft"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Site"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your refrigerator"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your office"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the interior of your bedroom"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "site"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000180",
+          "meta": {
+            "definition": {
+              "val": "Relates an entity in the ontology to the term that is used to represent it in the the CLIF specification of BFO2",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000232",
+                "val": "Really of interest to developers only"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
+                "val": "Person:Alan Ruttenberg"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "BFO CLIF specification label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "History"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "history"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "history"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000144",
+          "meta": {
+            "definition": {
+              "val": "b is a process_profile =Def. there is some process c such that b process_profile_of c (axiom label in BFO2 Reference: [093-002])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ProcessProfile"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b process_profile_of c holds when b proper_occurrent_part_of c& there is some proper_occurrent_part d of c which has no parts in common with b & is mutually dependent on b& is such that b, c and d occupy the same temporal region (axiom label in BFO2 Reference: [094-005])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "On a somewhat higher level of complexity are what we shall call rate process profiles, which are the targets of selective abstraction focused not on determinate quality magnitudes plotted over time, but rather on certain ratios between these magnitudes and elapsed times. A speed process profile, for example, is represented by a graph plotting against time the ratio of distance covered per unit of time. Since rates may change, and since such changes, too, may have rates of change, we have to deal here with a hierarchy of process profile universals at successive levels"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x y) (if (processProfileOf x y) (and (properContinuantPartOf x y) (exists (z t) (and (properOccurrentPartOf z y) (TemporalRegion t) (occupiesSpatioTemporalRegion x t) (occupiesSpatioTemporalRegion y t) (occupiesSpatioTemporalRegion z t) (not (exists (w) (and (occurrentPartOf w x) (occurrentPartOf w z))))))))) // axiom label in BFO2 CLIF: [094-005] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The simplest type of process profiles are what we shall call ‘quality process profiles’, which are the process profiles which serve as the foci of the sort of selective abstraction that is involved when measurements are made of changes in single qualities, as illustrated, for example, by process profiles of mass, temperature, aortic pressure, and so on."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ProcessProfile a) (exists (b) (and (Process b) (processProfileOf a b)))) // axiom label in BFO2 CLIF: [093-002] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "One important sub-family of rate process profiles is illustrated by the beat or frequency profiles of cyclical processes, illustrated by the 60 beats per minute beating process of John’s heart, or the 120 beats per minute drumming process involved in one of John’s performances in a rock band, and so on. Each such process includes what we shall call a beat process profile instance as part, a subtype of rate process profile in which the salient ratio is not distance covered but rather number of beat cycles per unit of time. Each beat process profile instance instantiates the determinable universal beat process profile. But it also instantiates multiple more specialized universals at lower levels of generality, selected from   rate process profilebeat process profileregular beat process profile3 bpm beat process profile4 bpm beat process profileirregular beat process profileincreasing beat process profileand so on.In the case of a regular beat process profile, a rate can be assigned in the simplest possible fashion by dividing the number of cycles by the length of the temporal region occupied by the beating process profile as a whole. Irregular process profiles of this sort, for example as identified in the clinic, or in the readings on an aircraft instrument panel, are often of diagnostic significance."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "process-profile"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "process profile"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000023",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a building in serving as a military target"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a stone in marking a property boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "Role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the student role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of subject in a clinical trial"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the priest role"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of a boundary to demarcate two neighboring administrative territories"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "role"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000145",
+          "meta": {
+            "definition": {
+              "val": "b is a relational quality = Def. for some independent continuants c, d and for some time t: b quality_of c at t & b quality_of d at t. (axiom label in BFO2 Reference: [057-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "r-quality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "RelationalQuality"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (RelationalQuality a) (exists (b c t) (and (IndependentContinuant b) (IndependentContinuant c) (qualityOfAt a b t) (qualityOfAt a c t)))) // axiom label in BFO2 CLIF: [057-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "a marriage bond, an instance of requited love, an obligation between one person and another."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "relational quality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000024",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Most examples of fiat object parts are associated with theoretically drawn divisions"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(forall (x) (if (FiatObjectPart x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y) (and (Object y) (properContinuantPartOfAt x y t)))))))) // axiom label in BFO2 CLIF: [027-004] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the upper and lower lobes of the left lung"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "FiatObjectPart"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "fiat-object-part"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the division of the brain into regions"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "b is a fiat object part = Def. b is a material entity which is such that for all times t, if b exists at t then there is some object c such that b proper continuant_part of  c at t and c is demarcated from the remainder of c by a two-dimensional continuant fiat boundary. (axiom label in BFO2 Reference: [027-004])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the division of the planet into hemispheres"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the Western hemisphere of the Earth"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the FMA:regional parts of an intact human body."
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the dorsal and ventral surfaces of the body"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "or with divisions drawn by cognitive subjects for practical reasons, such as the division of a cake (before slicing) into (what will become) slices (and thus member parts of an object aggregate). However, this does not mean that fiat object parts are dependent for their existence on divisions or delineations effected by cognitive subjects. If, for example, it is correct to conceive geological layers of the Earth as fiat object parts of the Earth, then even though these layers were first delineated in recent times, still existed long before such delineation and what holds of these layers (for example that the oldest layers are also the lowest layers) did not begin to hold because of our acts of delineation.Treatment of material entity in BFOExamples viewed by some as problematic cases for the trichotomy of fiat object part, object, and object aggregate include: a mussel on (and attached to) a rock, a slime mold, a pizza, a cloud, a galaxy, a railway train with engine and multiple carriages, a clonal stand of quaking aspen, a bacterial community (biofilm), a broken femur. Note that, as Aristotle already clearly recognized, such problematic cases – which lie at or near the penumbra of instances defined by the categories in question – need not invalidate these categories. The existence of grey objects does not prove that there are not objects which are black and objects which are white; the existence of mules does not prove that there are not objects which are donkeys and objects which are horses. It does, however, show that the examples in question need to be addressed carefully in order to show how they can be fitted into the proposed scheme, for example by recognizing additional subdivisions [29"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "fiat object part"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000146",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a two-dimensional continuant fiat boundary (surface) is a self-connected fiat surface whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [033-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "TwoDimensionalContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "2d-cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (TwoDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (TwoDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [033-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "two-dimensional continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000140",
+          "meta": {
+            "definition": {
+              "val": "b is a continuant fiat boundary = Def. b is an immaterial entity that is of zero, one or two dimensions and does not include a spatial region as part. (axiom label in BFO2 Reference: [029-001])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (ContinuantFiatBoundary a) (and (ImmaterialEntity a) (exists (b) (and (or (ZeroDimensionalSpatialRegion b) (OneDimensionalSpatialRegion b) (TwoDimensionalSpatialRegion b)) (forall (t) (locatedInAt a b t)))) (not (exists (c t) (and (SpatialRegion c) (continuantPartOfAt c a t)))))) // axiom label in BFO2 CLIF: [029-001] "
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: In BFO 1.1 the assumption was made that the external surface of a material entity such as a cell could be treated as if it were a boundary in the mathematical sense. The new document propounds the view that when we talk about external surfaces of material objects in this way then we are talking about something fiat. To be dealt with in a future version: fiat boundaries at different levels of granularity.More generally, the focus in discussion of boundaries in BFO 2.0 is now on fiat boundaries, which means: boundaries for which there is no assumption that they coincide with physical discontinuities. The ontology of boundaries becomes more closely allied with the ontology of regions."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000601",
+                "val": "Every continuant fiat boundary is located at some spatial region at every time at which it exists"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ContinuantFiatBoundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: a continuant fiat boundary is a boundary of some material entity (for example: the plane separating the Northern and Southern hemispheres; the North Pole), or it is a boundary of some immaterial entity (for example of some portion of airspace). Three basic kinds of continuant fiat boundary can be distinguished (together with various combination kinds [29"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Continuant fiat boundary doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the mereological sum of two-dimensional continuant fiat boundary and a one dimensional continuant fiat boundary that doesn't overlap it. The situation is analogous to temporal and spatial regions."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "continuant fiat boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000020",
+          "meta": {
+            "definition": {
+              "val": "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])",
+              "xrefs": []
+            },
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "of one-sided specifically dependent continuants: the mass of this tomato"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the disposition of this fish to decay"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mutual dependence of proton donors and acceptors in chemical reactions [79"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "SpecificallyDependentContinuant"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the role of being a doctor"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the pink color of a medium rare piece of grilled filet mignon at its center"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "sdc"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the smell of this portion of mozzarella"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the function of this heart: to pump blood"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the shape of this hole."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "specifically dependent continuant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000141",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "immaterial"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "ImmaterialEntity"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+                "val": "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "immaterial entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000142",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000600",
+                "val": "a one-dimensional continuant fiat boundary is a continuous fiat line whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [032-001])"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the median sulcus of your tongue"
+              },
+              {
+                "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+                "val": "http://purl.obolibrary.org/obo/bfo.owl"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "all lines of latitude and longitude"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "The Equator"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "the line separating the outer surface of the mucosa of the lower lip from the outer surface of the skin of the chin."
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000112",
+                "val": "all geopolitical boundaries"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0000602",
+                "val": "(iff (OneDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (OneDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [032-001] "
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000179",
+                "val": "1d-cf-boundary"
+              },
+              {
+                "pred": "http://purl.obolibrary.org/obo/BFO_0000180",
+                "val": "OneDimensionalContinuantFiatBoundary"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "one-dimensional continuant fiat boundary"
+        }
+      ],
+      "edges": [
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000018",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000004",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000146",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000024",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000147",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000008",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000009",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000017",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000029",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000027",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000006",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000040",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000019",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000020"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000141",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000004"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000031",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000020",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000002"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000034",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000023",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000145",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000140",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000141"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000144",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000011",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000030",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000001",
+          "pred": "is_a",
+          "obj": "http://www.w3.org/2002/07/owl#Thing"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000038",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000035",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000148",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000142",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000140"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000026",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000002",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000015",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000003"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000028",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000006"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000016",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000017"
+        }
+      ],
+      "id": "http://purl.obolibrary.org/obo/bfo.owl",
+      "meta": {
+        "subsets": [],
+        "xrefs": [],
+        "basicPropertyValues": [
+          {
+            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+            "val": "BFO 2 Reference: BFO does not claim to provide complete coverage of entities of all types. It seeks only to provide coverage of those entities studied by empirical science together with those entities which affect or are involved in human activities such as data processing and planning - coverage that is sufficiently broad to provide assistance to those engaged in building domain ontologies for purposes of data annotation."
+          },
+          {
+            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+            "val": "BFO 2 Reference: BFO's treatment of continuants and occurrents - as also its treatment of regions, rests on a dichotomy between space and time, and on the view that there are two perspectives on reality - earlier called the 'SNAP' and 'SPAN' perspectives, both of which are essential to the non-reductionist representation of reality as we understand it from the best available science."
+          },
+          {
+            "pred": "http://purl.obolibrary.org/obo/IAO_0000116",
+            "val": "BFO 2 Reference: For both terms and relational expressions in BFO, we distinguish between primitive and defined. 'Entity' is an example of a  primitive term. Primitive terms in a highest-level ontology such as BFO are terms that are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms."
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Alan Ruttenberg"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Albert Goldfain"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Barry Smith"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Bill Duncan"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Bjoern Peters"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Chris Mungall"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "David Osumi-Sutherland"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Fabian Neuhaus"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Holger Stenzhorn"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "James A. Overton"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Janna Hastings"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Jie Zheng"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Jonathan Bona"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Larry Hunter"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Leonard Jacuzzo"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Ludger Jansen"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Mark Ressler"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Mathias Brochhausen"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Mauricio Almeida"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Melanie Courtot"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Pierre Grenon"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Randall Dipert"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Ron Rudnicki"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Selja Seppälä"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Stefan Schulz"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Thomas Bittner"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Werner Ceusters"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Yongqun \"Oliver\" He"
+          },
+          {
+            "pred": "http://purl.org/dc/terms/license",
+            "val": "http://creativecommons.org/licenses/by/4.0/"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
+            "val": "Please see the project site https://github.com/BFO-ontology/BFO, the bfo2 owl discussion group http://groups.google.com/group/bfo-owl-devel, the bfo2 discussion group http://groups.google.com/group/bfo-devel, the tracking google doc http://goo.gl/IlrEE, and the current version of the bfo2 reference http://purl.obolibrary.org/obo/bfo/dev/bfo2-reference.docx. This ontology is generated from a specification at https://github.com/BFO-ontology/BFO/tree/master/src/ontology/owl-group/specification/ and with the code that generates the OWL version in https://github.com/BFO-ontology/BFO/tree/master/src/tools/. A very early version of BFO version 2 in CLIF is at http://purl.obolibrary.org/obo/bfo/dev/bfo.clif."
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
+            "val": "The BSD license on the BFO project site refers to code used to build BFO."
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#comment",
+            "val": "This BFO 2.0 version represents a major update to BFO and is not strictly backwards compatible with BFO 1.1. The previous OWL version of BFO, version 1.1.1 will remain available at http://ifomis.org/bfo/1.1 and will no longer be updated. The BFO 2.0 OWL is a classes-only specification. The incorporation of core relations has been held over for a later version."
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+            "val": "http://purl.obolibrary.org/obo/bfo/dev/bfo.clif"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+            "val": "https://github.com/BFO-ontology/BFO/tree/master/src/ontology/owl-group/specification/"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+            "val": "http://groups.google.com/group/bfo-devel"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+            "val": "http://groups.google.com/group/bfo-discuss"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+            "val": "http://groups.google.com/group/bfo-owl-devel"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+            "val": "http://purl.obolibrary.org/obo/bfo/dev/owl"
+          },
+          {
+            "pred": "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+            "val": "https://github.com/BFO-ontology/BFO/tree/master/src/tools/"
+          },
+          {
+            "pred": "http://xmlns.com/foaf/0.1/homepage",
+            "val": "http://basic-formal-ontology.org/"
+          },
+          {
+            "pred": "http://xmlns.com/foaf/0.1/homepage",
+            "val": "http://ifomis.org/bfo"
+          },
+          {
+            "pred": "http://xmlns.com/foaf/0.1/homepage",
+            "val": "https://github.com/BFO-ontology/BFO"
+          },
+          {
+            "pred": "http://xmlns.com/foaf/0.1/mbox",
+            "val": "mailto:bfo-owl-devel@googlegroups.com"
+          }
+        ],
+        "version": "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"
+      },
+      "equivalentNodesSets": [],
+      "logicalDefinitionAxioms": [],
+      "domainRangeAxioms": [],
+      "propertyChainAxioms": []
+    },
+    {
+      "nodes": [
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Represents the killing power of a disease, as the ratio of deaths to cases. The time interval is not specified. Not to be confused with mortality rate."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "case fatality rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000233",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Ability to identify every single case of disease."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "sensitivity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/VO_0000247",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Percentage reduction in disease incidence attributable to vaccination."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "vaccine efficacy"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#susceptible_individuals",
+          "type": "CLASS",
+          "lbl": "susceptible individuals"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCBITaxon_2759",
+          "type": "CLASS",
+          "lbl": "eukaryota"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of",
+          "type": "PROPERTY",
+          "lbl": "time boundary of"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
+          "type": "CLASS",
+          "lbl": "non-pharmaceutical interventions"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings",
+          "type": "CLASS",
+          "lbl": "percentage of laboratory findings"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0020000",
+          "type": "CLASS",
+          "lbl": "identifier"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#untraceable_contacts",
+          "type": "CLASS",
+          "lbl": "untraceable contacts"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events",
+          "type": "CLASS",
+          "lbl": "number of schools with exposure events"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000245",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Compares the risk of a health event (disease, injury, risk factor, or death) among one group with the risk among another group. Also called risk ratio."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "relative risk"
+        },
+        {
+          "id": "http://semanticscience.org/resource/SIO_000011",
+          "type": "PROPERTY",
+          "lbl": "is attribute of"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000568",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A data item that is the output of some infection case count and that represents the number of infectious disease cases that ended in death."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "total number of deaths"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000449",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A period of time that must elapse before those exposed to or attacked by a contagious disease can be considered as incapable respectively of developing or transmitting the disease."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "quarantine period"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000569",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A data item that is the output of some infection case count."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "total number of cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
+          "type": "CLASS",
+          "lbl": "number of cases with missing exposure information"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#odds_ratio_for_being_an_infected_contact",
+          "type": "CLASS",
+          "lbl": "odds ratio for being an infected contact"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#epidemic_doubling_time",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Time for a given quantity to double in size or number at a constant growth rate."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "epidemic doubling time"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality",
+          "type": "CLASS",
+          "lbl": "cumulative excess mortality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#environmental_risk_factor",
+          "type": "CLASS",
+          "lbl": "environmental risk factor"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#interpretation",
+          "type": "CLASS",
+          "lbl": "interpretation"
+        },
+        {
+          "id": "http://www.ebi.ac.uk/efo/EFO_0004804",
+          "type": "CLASS",
+          "lbl": "birth rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case",
+          "type": "CLASS",
+          "lbl": "initial infection case"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCIT_C67448",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The dose of pathogens received by the exposed individual."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "infectious dose"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0001343",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Period of time starting with the establishing of an infection in a host and ending when the host becomes contagious."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "latency period"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_hospitalized_this_week",
+          "type": "CLASS",
+          "lbl": "number of cases hospitalized this week"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_international_travel",
+          "type": "CLASS",
+          "lbl": "number of cases exposed by international travel"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_died",
+          "type": "CLASS",
+          "lbl": "median age of cases died"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBCS_0000064",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "It measures the frequency of all current cases (Old & New) existing during a defined period of time (e.g. annual prevalence) expressed in relation to a defined population."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "period prevalence"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000203",
+          "type": "CLASS",
+          "lbl": "cohort"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#serial_interval",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The time interval between symptom onset in a primary case and a secondary case, which is considered a reasonable approximation of the generation interval and is more practical to observe"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "serial interval"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#daily_deaths",
+          "type": "CLASS",
+          "lbl": "daily deaths"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_ever_hospitalized",
+          "type": "CLASS",
+          "lbl": "total number of cases ever hospitalized"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology",
+          "type": "CLASS",
+          "lbl": "descriptive epidemiology"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OAE_0001869",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The rate of population recovering from and infection."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "recovery rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Not all contacts will become infected and the average number of secondary cases per infectious case will be lower than the basic reproduction number. The effective reproductive number (R) is the average number of secondary cases per infectious case in a population made up of both susceptible and non-susceptible hosts."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "effective reproduction number"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#exposure",
+          "type": "CLASS",
+          "lbl": "exposure"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#generation_interval",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The time lag from a primary infection to a secondary infection caused by the primary infection."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "generation interval"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#herd_immunity_threshold",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The proportion of a population that need to be immune in order for an infectious disease to become stable in that community."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "herd immunity threshold"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0000087",
+          "type": "PROPERTY",
+          "lbl": "has role"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0000086",
+          "type": "PROPERTY",
+          "lbl": "has quality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel",
+          "type": "CLASS",
+          "lbl": "proportion of cases attributed to travel"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000482",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Cumulative incidence of infection during a specified period of time."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "incidence proportion"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates",
+          "type": "CLASS",
+          "lbl": "new daily case rates"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
+          "type": "PROPERTY",
+          "lbl": "left boundary of"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts",
+          "type": "CLASS",
+          "lbl": "epidemiological core concepts"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000484",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "It is the number of new events that occurs in a defined time period in a geographical area."
+              },
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A quality that inheres in an organism population and is the infection incidence proportion per unit time."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "infection incidence rate"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Chronoids are entities sui generis.\n\nEvery chronoid has exactly two extremal and\ninfinitely many inner time boundaries which are\nequivalently called time-points."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "chronoid"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens",
+          "type": "CLASS",
+          "lbl": "number of tested specimens"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBI_0100026",
+          "type": "CLASS",
+          "lbl": "organism"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBCS_0000052",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A data item that refers to the number of new events that have occurred in a specific time interval divided by the population at risk at the beginning of the time interval. The result gives the likelihood of developing an event in that time interval."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "incidence proportion ratio"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#hospitalization_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Proportion of confirmed cases that were hospitalized."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "hospitalization rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBI_0000181",
+          "type": "CLASS",
+          "lbl": "population"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000509",
+          "type": "CLASS",
+          "lbl": "organism population"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#quarantined_cases",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Confirmed and infected cases under quarantine."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "quarantined cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_icu",
+          "type": "CLASS",
+          "lbl": "percentage of cases icu"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBI_0000067",
+          "type": "CLASS",
+          "lbl": "evaluant role"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/PATO_0001415",
+          "type": "CLASS",
+          "lbl": "morbidity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#suspected_cases",
+          "type": "CLASS",
+          "lbl": "suspected cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Percent of positive specimens."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "rate cases by testing"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000030",
+          "type": "CLASS",
+          "lbl": "information content entity"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#has_right_time_boundary",
+          "type": "PROPERTY",
+          "lbl": "has right time boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000511",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Quantity of members of a population that have an infection."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "infected population"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Individual",
+          "type": "CLASS",
+          "lbl": "individual"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility",
+          "type": "CLASS",
+          "lbl": "per capita mobility"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Time",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The time model of GFO is based on Brentano and the glass continuum of Allen&Hayes."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "time"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000424",
+          "type": "CLASS",
+          "lbl": "risk difference"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tests",
+          "type": "CLASS",
+          "lbl": "number of tests"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBI_0000070",
+          "type": "CLASS",
+          "lbl": "assay"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Time Regions are defined as the mereological sum of chronoids,\ni.e. time regions may consist of non-connected intervals of time."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "temporal region"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_community_transmission",
+          "type": "CLASS",
+          "lbl": "rate of community transmission"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators",
+          "type": "CLASS",
+          "lbl": "other indicators"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Time boundaries depend on a chronoids and can coincide.\n\nLeft time boundaries, if viewed from the perspective of bounding a specific chronoid, are those which are earlier than any inner or right time boundary of that chronoid. On the other hand, within a pair of coincident time boundaries, a left time boundary is later than the right time boundary in that pair.\n\n[FL, 2008-02-27]"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "time boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0000059",
+          "type": "PROPERTY",
+          "lbl": "concretizes"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent",
+          "type": "CLASS",
+          "lbl": "occurrent"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0000057",
+          "type": "PROPERTY",
+          "lbl": "has participant"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#infectious_process",
+          "type": "CLASS",
+          "lbl": "infectious process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
+          "type": "CLASS",
+          "lbl": "number of cases exposed by local (one or cluster) case"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_hospitalized",
+          "type": "CLASS",
+          "lbl": "median age of cases hospitalized"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_died",
+          "type": "CLASS",
+          "lbl": "percentage cases died"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#caused_by",
+          "type": "PROPERTY",
+          "lbl": "caused by"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/GSSO_006827",
+          "type": "CLASS",
+          "lbl": "fertility rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A hospital-wide nosocomial infection rate/100 admissions for a given period (month, quarter, or year) is commonly calculated. In this rate, a patient who has two infections is actually counted twice."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "hospital-wide nosocomial infection rate per 100 admissions"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality",
+          "type": "CLASS",
+          "lbl": "percent increase in mortality"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure",
+          "type": "CLASS",
+          "lbl": "processual structure"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Number of exposed persons developing the disease within the range of incubation period following exposure to a primary case."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "secondary attack rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0002234",
+          "type": "PROPERTY",
+          "lbl": "has output"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+          "type": "CLASS",
+          "lbl": "person"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Indicates epidemic growth rate as the median percent change in daily numbers of new cases."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "percent daily change"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0002351",
+          "type": "PROPERTY",
+          "lbl": "has member"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases",
+          "type": "CLASS",
+          "lbl": "median age of cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#growth_rate",
+          "type": "CLASS",
+          "lbl": "growth rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCIT_C164332",
+          "type": "CLASS",
+          "lbl": "sequence identity of sample"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#right_boundary_of",
+          "type": "PROPERTY",
+          "lbl": "right boundary of"
+        },
+        {
+          "id": "http://purl.unep.org/sdg/SDGIO_00020030",
+          "type": "CLASS",
+          "lbl": "neonatal mortality rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_cases_with_at_least_one_comorbidity",
+          "type": "CLASS",
+          "lbl": "rate of cases with at least one comorbidity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts",
+          "type": "CLASS",
+          "lbl": "exposed contacts"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor",
+          "type": "CLASS",
+          "lbl": "risk factor"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#opportunity",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Number of daily contacts the infected person has; average number of opportunities a person has to spread the infection each day the person is infectious."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "opportunity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0002463",
+          "type": "PROPERTY",
+          "lbl": "target participant in"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#male-to-female_ratio",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Male-to-female ratio of confirmed case-patients"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "male-to-female ratio"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#exposed_individuals",
+          "type": "CLASS",
+          "lbl": "exposed individuals"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#predictive_value_positive",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The proportion of reported cases that actually have the health-related event under surveillance."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "predictive value positive (pvp)"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000414",
+          "type": "CLASS",
+          "lbl": "mortality rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#complication_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Proportion of confirmed cases that suffered complications."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "complication rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000412",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Ratio formed by the total number of all individuals who have an attribute or disease at a particular time or during a particular period divided by the populations at risk of having the attribute or disease at this point of time or midway through the period."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "prevalence"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The risk of infection is related to the extrinsic risk factors (use of devices such as ventilator, central line intravascular catheter, urinary catheter, surgical operation)."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "device-specific rates and procedure-specific rates"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates",
+          "type": "CLASS",
+          "lbl": "new daily death rates"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#exposition_interval",
+          "type": "CLASS",
+          "lbl": "exposition interval"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#protection_rate",
+          "type": "CLASS",
+          "lbl": "protection rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000109",
+          "type": "CLASS",
+          "lbl": "measurement datum"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000196",
+          "type": "CLASS",
+          "lbl": "confidence interval"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates",
+          "type": "CLASS",
+          "lbl": "cumulative case rates"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#has_left_time_boundary",
+          "type": "PROPERTY",
+          "lbl": "has left time boundary"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Concrete",
+          "type": "CLASS",
+          "lbl": "concrete"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000163",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A population of organisms that have been infected, but are no longer able to transmit the disease and to acquire the infection again."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "recovered cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases",
+          "type": "CLASS",
+          "lbl": "percentage of cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay",
+          "type": "CLASS",
+          "lbl": "length of icu stay"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#incidence_of_sever_outcomes",
+          "type": "CLASS",
+          "lbl": "incidence of sever outcomes"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected",
+          "type": "CLASS",
+          "lbl": "percentage of cases which are detected"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000054",
+          "type": "PROPERTY",
+          "lbl": "realized in"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000088",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Statistical sample size is a count evaluating the number of individual experimental units."
+              },
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A population is a group of material entities consisting of individuals which share a particular characteristic such as inhabiting a particular region or area or ability to interbreed."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "study group population size"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Average number of cases that will result from an index case."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "reproductive rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts",
+          "type": "CLASS",
+          "lbl": "rate of infectious contacts"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Left_time_boundary",
+          "type": "CLASS",
+          "lbl": "left time boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_mild_symptoms",
+          "type": "CLASS",
+          "lbl": "number of cases with mild symptoms"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#line_of_infection",
+          "type": "CLASS",
+          "lbl": "line of infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing",
+          "type": "CLASS",
+          "lbl": "number of cases by testing"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000296",
+          "type": "CLASS",
+          "lbl": "case"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence",
+          "type": "CLASS",
+          "lbl": "weighted prevalence"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000665",
+          "type": "CLASS",
+          "lbl": "source of infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000003",
+          "type": "CLASS",
+          "lbl": "measurement unit label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000425",
+          "type": "CLASS",
+          "lbl": "virulence factor"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_comorbidities_cases",
+          "type": "CLASS",
+          "lbl": "prevalence of comorbidities cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_removed_from_isolation_this_week",
+          "type": "CLASS",
+          "lbl": "number of cases removed from isolation this week"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000009",
+          "type": "CLASS",
+          "lbl": "datum label"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_deaths_new_this_week",
+          "type": "CLASS",
+          "lbl": "number of deaths new this week"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_removed",
+          "type": "CLASS",
+          "lbl": "percentage cases removed"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/TRANS_0000000",
+          "type": "CLASS",
+          "lbl": "transmission"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000140",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Length of time a person may transmit a microorganism; the duration of time a person is infectious"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "infectious period"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_asymptomatic_of_confirmed_cases",
+          "type": "CLASS",
+          "lbl": "percentage of asymptomatic of confirmed cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000136",
+          "type": "PROPERTY",
+          "lbl": "is about"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000658",
+          "type": "CLASS",
+          "lbl": "host exposure to infectious agent"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000519",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The time that passes between being exposed to something that can cause disease (such as radiation or a virus) and having symptoms."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "incubation period"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections",
+          "type": "CLASS",
+          "lbl": "relative change in new infections"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000182",
+          "type": "CLASS",
+          "lbl": "odds ratio"
+        },
+        {
+          "id": "http://www.orpha.net/ORDO/Orphanet_409966",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Type of prevalence where the data have been collected for one point of time."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "point prevalence"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OGMS_0000031",
+          "type": "CLASS",
+          "lbl": "disease"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Space",
+          "type": "CLASS",
+          "lbl": "space"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases",
+          "type": "CLASS",
+          "lbl": "new daily cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cases_by_exposure_in_a_healthcare_setting",
+          "type": "CLASS",
+          "lbl": "cases by exposure in a healthcare setting"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/RO_0002536",
+          "type": "PROPERTY",
+          "lbl": "has unit"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "type": "CLASS",
+          "lbl": "natural history"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary",
+          "type": "CLASS",
+          "lbl": "right time boundary"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000027",
+          "type": "CLASS",
+          "lbl": "data item"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#points_of_interest",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Number of points of interets within a geographical area."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "points of interest (pois)"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_hospital",
+          "type": "CLASS",
+          "lbl": "number of cases currently in hospital"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#distribution",
+          "type": "CLASS",
+          "lbl": "distribution"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Space_time",
+          "type": "CLASS",
+          "lbl": "space time entity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_icu",
+          "type": "CLASS",
+          "lbl": "number of cases currently in icu"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/VIDO_0001331",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Numerical expression of the quantity of virus in a given volume of fluid."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "viral load"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed",
+          "type": "CLASS",
+          "lbl": "period from infectious to confirmed"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000002",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The measure (R0) of the transmission potential of a disease such that the infection will be able to start spreading in a population or not. It is the average number of secondary infections produced by a typical case of an infection in a population where everyone is susceptible."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "basic reproduction number"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCIT_C17734",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Population groups with an increased likelihood of a disease or other health issue"
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "at-risk population"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cluster_size",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Number of cases of a disease or another health-related condition, closely grouped in time and place."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "cluster size"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/COVOC_0010003",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Any person meeting the laboratory criteria for COVID-19."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "confirmed cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#onset_of_symptom_to_hospitalization",
+          "type": "CLASS",
+          "lbl": "onset of symptom to hospitalization"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#daily_cases",
+          "type": "CLASS",
+          "lbl": "daily cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events",
+          "type": "CLASS",
+          "lbl": "number of cases with exposure events"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_active_cases",
+          "type": "CLASS",
+          "lbl": "number of active cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases",
+          "type": "CLASS",
+          "lbl": "cumulative cases"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters",
+          "type": "CLASS",
+          "lbl": "quantitative quality"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000463",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Likelihood any contact passes on an exposure."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "transmission probability"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/APOLLO_SV_00000497",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "A count of individuals in a population who meet the criteria of some case definition during some time interval."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "number of cases new this week"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000467",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Average susceptibility of the population; the share of the population capable of being infected."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "susceptibility"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000586",
+          "type": "CLASS",
+          "lbl": "infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000466",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The ratio of the number of cases of the disease in relation to the total number of individuals infected; a quality that inheres in an infectious agent and is the degree to which realizations of the infectious disease caused by the infectious agent become severe or fatal."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "virulence"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Event",
+          "type": "CLASS",
+          "lbl": "event"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#positive_contacts",
+          "type": "CLASS",
+          "lbl": "positive contacts"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#projects_to",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Links an entity to its temporal extension.\nEntities which are in time are related to the corresponding temporal regions by projects to. Moreover, entities related to others which are in time may likewise project to temporal regions.\n[FL, 2008-02-28]"
+              }
+            ]
+          },
+          "type": "PROPERTY",
+          "lbl": "projects to"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000134",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "The probability that a test will produce a true negative result when used on non-effected subjects as compared to a reference or \"gold standard\". The specificity of a test can be determined by calculating: number of true negative results divided by the sum of true negative results plus number of false positive results."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "diagnostic specificity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_female_sex",
+          "type": "CLASS",
+          "lbl": "percentage cases female sex"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Vaccination effort needed to eliminate an infection from a population."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "critical vaccination coverage"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OGMS_0000063",
+          "type": "CLASS",
+          "lbl": "line of disease"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCIT_C164607",
+          "type": "CLASS",
+          "lbl": "gene sequence identity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#testing_rate",
+          "type": "CLASS",
+          "lbl": "testing rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case",
+          "type": "CLASS",
+          "lbl": "initial exposed case"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Represents the proportion of deaths among all infected individuals, including all asymptomatic and undiagnosed subjects."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "infection fatality rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/has_confidence_level",
+          "type": "PROPERTY",
+          "lbl": "has confidence level"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events",
+          "type": "CLASS",
+          "lbl": "number of cases with school exposure events"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection",
+          "type": "CLASS",
+          "lbl": "duration of infection"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_sars-cov-2_seropositivity",
+          "type": "CLASS",
+          "lbl": "prevalence of sars-cov-2 seropositivity"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#host_risk_factor",
+          "type": "CLASS",
+          "lbl": "host risk factor"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_no_symptoms",
+          "type": "CLASS",
+          "lbl": "number of cases with no symptoms"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts",
+          "type": "CLASS",
+          "lbl": "average rate of infectious contacts"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/STATO_0000129",
+          "type": "PROPERTY",
+          "lbl": "has value"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IDO_0000458",
+          "type": "CLASS",
+          "lbl": "contagiousness"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#etiology",
+          "type": "CLASS",
+          "lbl": "etiology"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/IAO_0000219",
+          "type": "PROPERTY",
+          "lbl": "denotes"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/OBI_0000011",
+          "type": "CLASS",
+          "lbl": "planned process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt",
+          "type": "CLASS",
+          "lbl": "average daily number of new infections generated per case (rt)"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#attack_rate",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Number of new cases of a specified disease during a specified time interval per 100 populations at risk during the same time interval."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "attack rate"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions",
+          "meta": {
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.org/dc/terms/description",
+                "val": "Hospital-wide patient infection rate/100 admissions are used to avoid the pitfall of multiple infections in the same patient. This rate may be calculated for a given period: month, quarter, and year. In this rate, a patient with two infections is counted only once."
+              }
+            ]
+          },
+          "type": "CLASS",
+          "lbl": "hospital-wide patient infection rate per 100 admissions"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#undetected_cases",
+          "type": "CLASS",
+          "lbl": "undetected cases"
+        },
+        {
+          "id": "http://www.onto-med.de/ontologies/gfo.owl#Process",
+          "type": "CLASS",
+          "lbl": "process"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
+          "type": "CLASS",
+          "lbl": "number of cases exposed by local unknown exposure"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_removed_from_isolation",
+          "type": "CLASS",
+          "lbl": "total number of cases removed from isolation"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates",
+          "type": "CLASS",
+          "lbl": "cumulative death rates"
+        }
+      ],
+      "edges": [
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#etiology",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_female_sex",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposure",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#incidence_of_sever_outcomes",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000181",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#complication_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quarantined_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Concrete"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#environmental_risk_factor",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#positive_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C164332",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C164607",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.ebi.ac.uk/efo/EFO_0004804",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBCS_0000052",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/GSSO_006827",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000088",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000484",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000009",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_missing_exposure_information",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space_time",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Individual"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C17734",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cluster_size",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBCS_0000064",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/NCBITaxon_2759"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OGMS_0000031",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_removed_from_isolation",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000109",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Space_time"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000482",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000414",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#line_of_infection",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_hospitalized_this_week",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#odds_ratio_for_being_an_infected_contact",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_died",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000296",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#untraceable_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tests",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Left_time_boundary",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/PATO_0001415",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000027",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000203",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000658",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#exposure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000030",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000031"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000001"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000181",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_hospital",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_mild_symptoms",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000425",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C67448",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cases_by_exposure_in_a_healthcare_setting",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time"
+        },
+        {
+          "sub": "http://purl.unep.org/sdg/SDGIO_00020030",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000509",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000027"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_one_or_cluster_case",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Process",
+          "pred": "http://www.onto-med.de/ontologies/gfo.owl#projects_to",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000008"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#right_boundary_of",
+          "pred": "subPropertyOf",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#growth_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#total_number_of_cases_ever_hospitalized",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#health_systems_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCBITaxon_2759",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/OBI_0100026"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/VO_0000247",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000519",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/TRANS_0000000",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/COVOC_0010003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_icu",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_sars-cov-2_seropositivity",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Process",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Processual_Structure"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/BFO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_community_transmission",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_asymptomatic_of_confirmed_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000463",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#undetected_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000449",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Event",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Occurrent"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposition_interval",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#testing_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000163",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#other_indicators"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#prevalence_of_comorbidities_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#risk_factors_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Concrete",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Individual"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#hospitalization_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#has_right_time_boundary",
+          "pred": "inverseOf",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#right_boundary_of"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#has_left_time_boundary",
+          "pred": "inverseOf",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000569",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0100026",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#daily_deaths",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_hospitalized",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000019"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#opportunity",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#epidemic_doubling_time",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000140",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OGMS_0000031",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_international_travel",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000568",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space",
+          "pred": "is_a",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#Space_time"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#suspected_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#serial_interval",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000233",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_deaths_new_this_week",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_cases_removed",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#protection_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000466",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.orpha.net/ORDO/Orphanet_409966",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Time",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#daily_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000245",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#service_coverage_indicators",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#health_status_indicators"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000467",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000070",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/OBI_0000011"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0020000",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000030"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#interpretation",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#epidemiological_core_concepts"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000134",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000665",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000458",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/RO_0002463",
+          "pred": "subPropertyOf",
+          "obj": "http://www.w3.org/2002/07/owl#topObjectProperty"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#points_of_interest",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OGMS_0000063",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_removed_from_isolation_this_week",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000182",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#Space",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#herd_immunity_threshold",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/VIDO_0001331",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000665",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#infectious_process",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_active_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000425",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000196",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000027"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OAE_0001869",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000203",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/OBI_0000181"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000424",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000219",
+          "pred": "subPropertyOf",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000136"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases_died",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#susceptible_individuals",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/STATO_0000412",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#distribution",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#host_risk_factor",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#risk_factor"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposed_individuals",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000497",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000458",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000016"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#predictive_value_positive",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_currently_in_icu",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#onset_of_symptom_to_hospitalization",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#generation_interval",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#exposure",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000511",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_no_symptoms",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000067",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000023"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#median_age_of_cases",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
+          "pred": "subPropertyOf",
+          "obj": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#male-to-female_ratio",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#rate_of_cases_with_at_least_one_comorbidity",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000586",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000040"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OGMS_0000063",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#descriptive_epidemiology"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IAO_0000003",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/IAO_0000009"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0000586",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/NCIT_C67448",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/OBI_0000011",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/BFO_0000015"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#attack_rate",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/IDO_0001343",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_exposed_by_local_unknown_exposure",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000002",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters"
+        },
+        {
+          "sub": "http://purl.obolibrary.org/obo/APOLLO_SV_00000296",
+          "pred": "is_a",
+          "obj": "http://purl.obolibrary.org/obo/cemo.owl#interpretation"
+        }
+      ],
+      "id": "http://purl.obolibrary.org/obo/cemo.owl",
+      "meta": {
+        "subsets": [],
+        "xrefs": [],
+        "basicPropertyValues": [
+          {
+            "pred": "http://purl.obolibrary.org/obo/IAO_0000119",
+            "val": "The COVID-19 Epidemiology and Monitoring Ontology (CEMO) provides a model for describing, sharing and integrating of COVID-19 epidemiological data for outbreak monitoring and research."
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Elena de la Calle"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "Philippe Rocca-Serra"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0001-8149-5890"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0001-8888-635X"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0002-5111-7263"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0002-8691-772X"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0003-0351-6523"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/contributor",
+            "val": "https://orcid.org/0000-0003-1795-5930"
+          },
+          {
+            "pred": "http://purl.org/dc/elements/1.1/creator",
+            "val": "http://orcid.org/0000-0003-0169-8159"
+          },
+          {
+            "pred": "http://purl.org/dc/terms/issued",
+            "val": "16-05-2021"
+          },
+          {
+            "pred": "http://purl.org/dc/terms/license",
+            "val": "https://creativecommons.org/licenses/by/4.0/"
+          },
+          {
+            "pred": "http://purl.org/dc/terms/title",
+            "val": "COVID-19 Epidemiology and Monitoring Ontology (CEMO)"
+          },
+          {
+            "pred": "http://www.w3.org/2002/07/owl#versionInfo",
+            "val": "16-05-2021"
+          }
+        ],
+        "version": "http://purl.obolibrary.org/obo/cemo/releases/16-05-2021/cemo.owl"
+      },
+      "equivalentNodesSets": [
+        {
+          "nodeIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://www.onto-med.de/ontologies/gfo.owl#Process"
+          ]
+        },
+        {
+          "nodeIds": [
+            "http://purl.obolibrary.org/obo/OBI_0000181",
+            "http://purl.obolibrary.org/obo/IDO_0000509"
+          ]
+        },
+        {
+          "nodeIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000035",
+            "http://www.onto-med.de/ontologies/gfo.owl#Event"
+          ]
+        }
+      ],
+      "logicalDefinitionAxioms": [
+        {
+          "definedClassId": "http://www.onto-med.de/ontologies/gfo.owl#Left_time_boundary",
+          "genusIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+          ],
+          "restrictions": [
+            {
+              "propertyId": "http://www.onto-med.de/ontologies/gfo.owl#left_boundary_of",
+              "fillerId": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid"
+            }
+          ]
+        },
+        {
+          "definedClassId": "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary",
+          "genusIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+          ],
+          "restrictions": [
+            {
+              "propertyId": "http://www.onto-med.de/ontologies/gfo.owl#right_boundary_of",
+              "fillerId": "http://www.onto-med.de/ontologies/gfo.owl#Chronoid"
+            }
+          ]
+        }
+      ],
+      "domainRangeAxioms": [
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/cemo.owl#caused_by",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000015"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000015"
+          ]
+        },
+        {
+          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#has_left_time_boundary",
+          "rangeClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Left_time_boundary"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/RO_0000059",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000020"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000031"
+          ]
+        },
+        {
+          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#projects_to",
+          "rangeClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Time"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/has_confidence_level",
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/STATO_0000196"
+          ]
+        },
+        {
+          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of",
+          "domainClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Time_boundary"
+          ],
+          "rangeClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Temporal_region"
+          ]
+        },
+        {
+          "predicateId": "http://www.onto-med.de/ontologies/gfo.owl#has_right_time_boundary",
+          "rangeClassIds": [
+            "http://www.onto-med.de/ontologies/gfo.owl#Right_time_boundary"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/RO_0002234",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000015"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/IAO_0000030"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/RO_0000087",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000004"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000023"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/BFO_0000054",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000017"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000015"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/RO_0000086",
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/BFO_0000019"
+          ]
+        },
+        {
+          "predicateId": "http://purl.obolibrary.org/obo/RO_0002351",
+          "domainClassIds": [
+            "http://purl.obolibrary.org/obo/OBI_0000181"
+          ],
+          "rangeClassIds": [
+            "http://purl.obolibrary.org/obo/NCBITaxon_9606"
+          ]
+        }
+      ],
+      "propertyChainAxioms": []
+    }
+  ]
+}

--- a/owl/cemo.obo
+++ b/owl/cemo.obo
@@ -1,0 +1,1225 @@
+format-version: 1.2
+data-version: releases/16-05-2021
+import: http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl
+ontology: cemo
+property_value: http://purl.org/dc/elements/1.1/contributor "Elena de la Calle" xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0001-8149-5890 xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0001-8888-635X xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0002-5111-7263 xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0002-8691-772X xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0003-0351-6523 xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0003-1795-5930 xsd:string
+property_value: http://purl.org/dc/elements/1.1/contributor "Philippe Rocca-Serra" xsd:string
+property_value: http://purl.org/dc/elements/1.1/creator http://orcid.org/0000-0003-0169-8159
+property_value: http://purl.org/dc/terms/issued "16-05-2021" xsd:string
+property_value: http://purl.org/dc/terms/license https://creativecommons.org/licenses/by/4.0/
+property_value: http://purl.org/dc/terms/title "COVID-19 Epidemiology and Monitoring Ontology (CEMO)" xsd:string
+property_value: IAO:0000119 "The COVID-19 Epidemiology and Monitoring Ontology (CEMO) provides a model for describing, sharing and integrating of COVID-19 epidemiological data for outbreak monitoring and research." xsd:string
+property_value: owl:versionInfo "16-05-2021" xsd:string
+owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000449>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000008>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000015>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/COVOC_0010003>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/GSSO_006827>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000463>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000467>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000482>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000484>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000511>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000519>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0001343>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_9606>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164332>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164607>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C17734>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000052>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000064>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/PATO_0001415>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000088>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000134>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000182>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000245>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000412>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000414>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000424>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cluster_size>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#daily_deaths>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#generation_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infectious_process>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tests>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#opportunity>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#points_of_interest>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#positive_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#protection_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#serial_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#suspected_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#testing_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence>))\nDeclaration(Class(<http://purl.unep.org/sdg/SDGIO_00020030>))\nDeclaration(Class(<http://www.ebi.ac.uk/efo/EFO_0004804>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Chronoid>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary>))\nDeclaration(Class(<http://www.orpha.net/ORDO/Orphanet_409966>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000057>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/cemo.owl#caused_by>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#projects_to>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of>))\n\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000002> (basic reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> (infectious period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> (quarantine period)\n\n\n# Class: <http://purl.obolibrary.org/obo/COVOC_0010003> (confirmed cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/GSSO_006827> (fertility rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000463> (transmission probability)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000467> (susceptibility)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000482> (incidence proportion)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000484> (infection incidence rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000511> (infected population)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000519> (incubation period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0000519> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0001343> (latency period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0001343> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164332> (sequence identity of sample)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164607> (gene sequence identity)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C17734> (at-risk population)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000052> (incidence proportion ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000064> (period prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/PATO_0001415> (morbidity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000088> (study group population size)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000134> (diagnostic specificity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000182> (odds ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000245> (relative risk)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000412> (prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000414> (mortality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000424> (risk difference)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> (attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> (average daily number of new infections generated per case (rt))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> (average rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> (case fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> (cluster size)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> (critical vaccination coverage)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> (cumulative case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> (cumulative cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> (cumulative death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> (cumulative excess mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> (daily deaths)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> (device-specific rates and procedure-specific rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> (duration of infection)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> (effective reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> (exposed contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> (generation interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> (hospital-wide nosocomial infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> (hospital-wide patient infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> (infection fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> (initial exposed case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> (initial infection case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> (length of icu stay)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> (new daily case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> (new daily cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> (new daily death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> (non-pharmaceutical interventions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> (number of cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> (number of cases with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> (number of cases with school exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> (number of schools with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> (number of tested specimens)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> (number of tests)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#opportunity> (opportunity)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> (per capita mobility)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> (percent daily change)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> (percent increase in mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> (percentage of cases which are detected)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> (percentage of laboratory findings)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> (period from infectious to confirmed)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> (points of interest (pois))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> (positive contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> (proportion of cases attributed to travel)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> (protection rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> (quantitative quality)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> (rate cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> (rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> (relative change in new infections)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> (reproductive rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> (secondary attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> (serial interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> (suspected cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> (testing rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> (weighted prevalence)\n\n\n# Class: <http://purl.unep.org/sdg/SDGIO_00020030> (neonatal mortality rate)\n\n\n# Class: <http://www.ebi.ac.uk/efo/EFO_0004804> (birth rate)\n\n\n# Class: <http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> (time boundary)\n\nEquivalentClasses(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> ObjectSomeValuesFrom(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of> <http://purl.obolibrary.org/obo/BFO_0000008>))\n\n# Class: <http://www.orpha.net/ORDO/Orphanet_409966> (point prevalence)\n\n\n\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C164332> <http://purl.obolibrary.org/obo/NCIT_C164607> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\n)
+
+[Term]
+id: APOLLO_SV:00000002
+name: basic reproduction number
+is_a: quantitative_parameters ! quantitative quality
+disjoint_from: APOLLO_SV:00000140 ! infectious period
+disjoint_from: APOLLO_SV:00000140 ! infectious period
+disjoint_from: APOLLO_SV:00000140 ! infectious period
+disjoint_from: APOLLO_SV:00000140 ! infectious period
+relationship: IAO:0000136 IDO:0000458 ! is about contagiousness
+relationship: SIO:000011 Time ! is attribute of time
+property_value: http://purl.org/dc/terms/description "The measure (R0) of the transmission potential of a disease such that the infection will be able to start spreading in a population or not. It is the average number of secondary infections produced by a typical case of an infection in a population where everyone is susceptible." xsd:string
+
+[Term]
+id: APOLLO_SV:00000140
+name: infectious period
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Length of time a person may transmit a microorganism; the duration of time a person is infectious" xsd:string
+
+[Term]
+id: APOLLO_SV:00000163
+name: recovered cases
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A population of organisms that have been infected, but are no longer able to transmit the disease and to acquire the infection again." xsd:string
+
+[Term]
+id: APOLLO_SV:00000296
+name: case
+is_a: IAO:0000030 ! information content entity
+is_a: interpretation ! interpretation
+
+[Term]
+id: APOLLO_SV:00000449
+name: quarantine period
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A period of time that must elapse before those exposed to or attacked by a contagious disease can be considered as incapable respectively of developing or transmitting the disease." xsd:string
+
+[Term]
+id: APOLLO_SV:00000497
+name: number of cases new this week
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A count of individuals in a population who meet the criteria of some case definition during some time interval." xsd:string
+
+[Term]
+id: APOLLO_SV:00000568
+name: total number of deaths
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A data item that is the output of some infection case count and that represents the number of infectious disease cases that ended in death." xsd:string
+
+[Term]
+id: APOLLO_SV:00000569
+name: total number of cases
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A data item that is the output of some infection case count." xsd:string
+
+[Term]
+id: BFO:0000015
+equivalent_to: Process ! process
+
+[Term]
+id: BFO:0000035
+equivalent_to: Event ! event
+
+[Term]
+id: BFO:0000182
+name: natural history
+is_a: interpretation ! interpretation
+
+[Term]
+id: COVOC:0010003
+name: confirmed cases
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Any person meeting the laboratory criteria for COVID-19." xsd:string
+
+[Term]
+id: Chronoid
+name: chronoid
+is_a: Temporal_region ! temporal region
+relationship: has_left_time_boundary BFO:0000001 {cardinality="1"}
+relationship: has_right_time_boundary BFO:0000001 {cardinality="1"}
+property_value: http://purl.org/dc/terms/description "Chronoids are entities sui generis.\n\nEvery chronoid has exactly two extremal and\ninfinitely many inner time boundaries which are\nequivalently called time-points." xsd:string
+
+[Term]
+id: Concrete
+name: concrete
+is_a: Individual ! individual
+
+[Term]
+id: EFO:0004804
+name: birth rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: Event
+name: event
+is_a: Occurrent ! occurrent
+
+[Term]
+id: GSSO:006827
+name: fertility rate
+is_a: quantitative_parameters ! quantitative quality
+disjoint_from: IDO:0000482 ! incidence proportion
+
+[Term]
+id: IAO:0000003
+name: measurement unit label
+is_a: IAO:0000009 ! datum label
+
+[Term]
+id: IAO:0000009
+name: datum label
+is_a: IAO:0000030 ! information content entity
+
+[Term]
+id: IAO:0000027
+name: data item
+is_a: IAO:0000030 ! information content entity
+
+[Term]
+id: IAO:0000030
+name: information content entity
+is_a: BFO:0000031
+
+[Term]
+id: IAO:0000109
+name: measurement datum
+is_a: IAO:0000027 ! data item
+
+[Term]
+id: IAO:0020000
+name: identifier
+is_a: IAO:0000030 ! information content entity
+
+[Term]
+id: IDO:0000425
+name: virulence factor
+is_a: BFO:0000016
+is_a: interpretation ! interpretation
+
+[Term]
+id: IDO:0000458
+name: contagiousness
+is_a: BFO:0000016
+is_a: interpretation ! interpretation
+
+[Term]
+id: IDO:0000463
+name: transmission probability
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 APOLLO_SV:00000296 ! is about case
+relationship: IAO:0000136 IDO:0000458 ! is about contagiousness
+relationship: IAO:0000136 IDO:0000466 ! is about virulence
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+property_value: http://purl.org/dc/terms/description "Likelihood any contact passes on an exposure." xsd:string
+
+[Term]
+id: IDO:0000466
+name: virulence
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The ratio of the number of cases of the disease in relation to the total number of individuals infected; a quality that inheres in an infectious agent and is the degree to which realizations of the infectious disease caused by the infectious agent become severe or fatal." xsd:string
+
+[Term]
+id: IDO:0000467
+name: susceptibility
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Average susceptibility of the population; the share of the population capable of being infected." xsd:string
+
+[Term]
+id: IDO:0000482
+name: incidence proportion
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 IDO:0000586 ! is about infection
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+property_value: http://purl.org/dc/terms/description "Cumulative incidence of infection during a specified period of time." xsd:string
+
+[Term]
+id: IDO:0000484
+name: infection incidence rate
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 distribution ! is about distribution
+relationship: IAO:0000136 IDO:0000665 ! is about source of infection
+relationship: SIO:000011 Space ! is attribute of space
+property_value: http://purl.org/dc/terms/description "A quality that inheres in an organism population and is the infection incidence proportion per unit time." xsd:string
+property_value: http://purl.org/dc/terms/description "It is the number of new events that occurs in a defined time period in a geographical area." xsd:string
+
+[Term]
+id: IDO:0000509
+name: organism population
+is_a: BFO:0000027
+equivalent_to: OBI:0000181 ! population
+
+[Term]
+id: IDO:0000511
+name: infected population
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Quantity of members of a population that have an infection." xsd:string
+
+[Term]
+id: IDO:0000519
+name: incubation period
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The time that passes between being exposed to something that can cause disease (such as radiation or a virus) and having symptoms." xsd:string
+
+[Term]
+id: IDO:0000586
+name: infection
+is_a: BFO:0000040
+is_a: interpretation ! interpretation
+
+[Term]
+id: IDO:0000658
+name: host exposure to infectious agent
+is_a: exposure ! exposure
+
+[Term]
+id: IDO:0000665
+name: source of infection
+is_a: BFO:0000040
+is_a: interpretation ! interpretation
+
+[Term]
+id: IDO:0001343
+name: latency period
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Period of time starting with the establishing of an infection in a host and ending when the host becomes contagious." xsd:string
+
+[Term]
+id: Individual
+name: individual
+
+[Term]
+id: Left_time_boundary
+name: left time boundary
+is_a: Time_boundary ! time boundary
+intersection_of: Time_boundary ! time boundary
+intersection_of: left_boundary_of Chronoid ! chronoid
+
+[Term]
+id: NCBITaxon:2759
+name: eukaryota
+is_a: OBI:0100026 ! organism
+
+[Term]
+id: NCBITaxon:9606
+name: person
+is_a: descriptive_epidemiology ! descriptive epidemiology
+is_a: NCBITaxon:2759 ! eukaryota
+
+[Term]
+id: NCIT:C164332
+name: sequence identity of sample
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: NCIT:C164607
+name: gene sequence identity
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: NCIT:C17734
+name: at-risk population
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Population groups with an increased likelihood of a disease or other health issue" xsd:string
+
+[Term]
+id: NCIT:C67448
+name: infectious dose
+is_a: interpretation ! interpretation
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The dose of pathogens received by the exposed individual." xsd:string
+
+[Term]
+id: OAE:0001869
+name: recovery rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The rate of population recovering from and infection." xsd:string
+
+[Term]
+id: OBCS:0000052
+name: incidence proportion ratio
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 IDO:0000458 ! is about contagiousness
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+property_value: http://purl.org/dc/terms/description "A data item that refers to the number of new events that have occurred in a specific time interval divided by the population at risk at the beginning of the time interval. The result gives the likelihood of developing an event in that time interval." xsd:string
+
+[Term]
+id: OBCS:0000064
+name: period prevalence
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "It measures the frequency of all current cases (Old & New) existing during a defined period of time (e.g. annual prevalence) expressed in relation to a defined population." xsd:string
+
+[Term]
+id: OBI:0000011
+name: planned process
+is_a: BFO:0000015
+
+[Term]
+id: OBI:0000067
+name: evaluant role
+is_a: BFO:0000023
+
+[Term]
+id: OBI:0000070
+name: assay
+is_a: OBI:0000011 ! planned process
+
+[Term]
+id: OBI:0000181
+name: population
+is_a: BFO:0000040
+is_a: interpretation ! interpretation
+
+[Term]
+id: OBI:0100026
+name: organism
+is_a: BFO:0000040
+
+[Term]
+id: OGMS:0000031
+name: disease
+is_a: BFO:0000016
+is_a: interpretation ! interpretation
+
+[Term]
+id: OGMS:0000063
+name: line of disease
+is_a: BFO:0000015
+is_a: descriptive_epidemiology ! descriptive epidemiology
+
+[Term]
+id: Occurrent
+name: occurrent
+is_a: Processual_Structure ! processual structure
+disjoint_from: Process ! process
+
+[Term]
+id: Orphanet:409966
+name: point prevalence
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 exposure ! is about exposure
+relationship: IAO:0000136 IDO:0000519 ! is about incubation period
+relationship: IAO:0000136 TRANS:0000000 ! is about transmission
+relationship: SIO:000011 Time ! is attribute of time
+property_value: http://purl.org/dc/terms/description "Type of prevalence where the data have been collected for one point of time." xsd:string
+
+[Term]
+id: PATO:0001415
+name: morbidity
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: Process
+name: process
+is_a: Processual_Structure ! processual structure
+relationship: projects_to BFO:0000008
+
+[Term]
+id: Processual_Structure
+name: processual structure
+is_a: Concrete ! concrete
+
+[Term]
+id: Right_time_boundary
+name: right time boundary
+is_a: Time_boundary ! time boundary
+intersection_of: Time_boundary ! time boundary
+intersection_of: right_boundary_of Chronoid ! chronoid
+
+[Term]
+id: SDGIO:00020030
+name: neonatal mortality rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: STATO:0000088
+name: study group population size
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A population is a group of material entities consisting of individuals which share a particular characteristic such as inhabiting a particular region or area or ability to interbreed." xsd:string
+property_value: http://purl.org/dc/terms/description "Statistical sample size is a count evaluating the number of individual experimental units." xsd:string
+
+[Term]
+id: STATO:0000134
+name: diagnostic specificity
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The probability that a test will produce a true negative result when used on non-effected subjects as compared to a reference or \"gold standard\". The specificity of a test can be determined by calculating: number of true negative results divided by the sum of true negative results plus number of false positive results." xsd:string
+
+[Term]
+id: STATO:0000182
+name: odds ratio
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 exposure ! is about exposure
+relationship: IAO:0000136 risk_factor ! is about risk factor
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+
+[Term]
+id: STATO:0000196
+name: confidence interval
+is_a: IAO:0000027 ! data item
+
+[Term]
+id: STATO:0000203
+name: cohort
+is_a: interpretation ! interpretation
+is_a: OBI:0000181 ! population
+
+[Term]
+id: STATO:0000233
+name: sensitivity
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Ability to identify every single case of disease." xsd:string
+
+[Term]
+id: STATO:0000245
+name: relative risk
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 risk_factor ! is about risk factor
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+relationship: SIO:000011 Time ! is attribute of time
+property_value: http://purl.org/dc/terms/description "Compares the risk of a health event (disease, injury, risk factor, or death) among one group with the risk among another group. Also called risk ratio." xsd:string
+
+[Term]
+id: STATO:0000412
+name: prevalence
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Ratio formed by the total number of all individuals who have an attribute or disease at a particular time or during a particular period divided by the populations at risk of having the attribute or disease at this point of time or midway through the period." xsd:string
+
+[Term]
+id: STATO:0000414
+name: mortality rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: STATO:0000424
+name: risk difference
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: Space
+name: space
+is_a: descriptive_epidemiology ! descriptive epidemiology
+is_a: Space_time ! space time entity
+disjoint_from: Time ! time
+
+[Term]
+id: Space_time
+name: space time entity
+is_a: Individual ! individual
+
+[Term]
+id: TRANS:0000000
+name: transmission
+is_a: BFO:0000015
+is_a: interpretation ! interpretation
+
+[Term]
+id: Temporal_region
+name: temporal region
+is_a: Time ! time
+disjoint_from: Time_boundary ! time boundary
+property_value: http://purl.org/dc/terms/description "Time Regions are defined as the mereological sum of chronoids,\ni.e. time regions may consist of non-connected intervals of time." xsd:string
+
+[Term]
+id: Time
+name: time
+is_a: descriptive_epidemiology ! descriptive epidemiology
+is_a: Space_time ! space time entity
+property_value: http://purl.org/dc/terms/description "The time model of GFO is based on Brentano and the glass continuum of Allen&Hayes." xsd:string
+
+[Term]
+id: Time_boundary
+name: time boundary
+is_a: Time ! time
+union_of: Left_time_boundary ! left time boundary
+union_of: Right_time_boundary ! right time boundary
+property_value: http://purl.org/dc/terms/description "Time boundaries depend on a chronoids and can coincide.\n\nLeft time boundaries, if viewed from the perspective of bounding a specific chronoid, are those which are earlier than any inner or right time boundary of that chronoid. On the other hand, within a pair of coincident time boundaries, a left time boundary is later than the right time boundary in that pair.\n\n[FL, 2008-02-27]" xsd:string
+
+[Term]
+id: VIDO:0001331
+name: viral load
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Numerical expression of the quantity of virus in a given volume of fluid." xsd:string
+
+[Term]
+id: VO:0000247
+name: vaccine efficacy
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Percentage reduction in disease incidence attributable to vaccination." xsd:string
+
+[Term]
+id: attack_rate
+name: attack rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Number of new cases of a specified disease during a specified time interval per 100 populations at risk during the same time interval." xsd:string
+
+[Term]
+id: average_daily_number_of_new_infections_generated_per_case_rt
+name: average daily number of new infections generated per case (rt)
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: average_rate_of_infectious_contacts
+name: average rate of infectious contacts
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: case_fatality_rate
+name: case fatality rate
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 APOLLO_SV:00000296 ! is about case
+relationship: IAO:0000136 IDO:0000458 ! is about contagiousness
+relationship: IAO:0000136 IDO:0000466 ! is about virulence
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+property_value: http://purl.org/dc/terms/description "Represents the killing power of a disease, as the ratio of deaths to cases. The time interval is not specified. Not to be confused with mortality rate." xsd:string
+
+[Term]
+id: cases_by_exposure_in_a_healthcare_setting
+name: cases by exposure in a healthcare setting
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: cluster_size
+name: cluster size
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Number of cases of a disease or another health-related condition, closely grouped in time and place." xsd:string
+
+[Term]
+id: complication_rate
+name: complication rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Proportion of confirmed cases that suffered complications." xsd:string
+
+[Term]
+id: critical_vaccination_coverage
+name: critical vaccination coverage
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Vaccination effort needed to eliminate an infection from a population." xsd:string
+
+[Term]
+id: cumulative_case_rates
+name: cumulative case rates
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: cumulative_cases
+name: cumulative cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: cumulative_death_rates
+name: cumulative death rates
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: cumulative_excess_mortality
+name: cumulative excess mortality
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: daily_cases
+name: daily cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: daily_deaths
+name: daily deaths
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: descriptive_epidemiology
+name: descriptive epidemiology
+is_a: epidemiological_core_concepts ! epidemiological core concepts
+
+[Term]
+id: device-specific_rates_and_procedure-specific_rates
+name: device-specific rates and procedure-specific rates
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The risk of infection is related to the extrinsic risk factors (use of devices such as ventilator, central line intravascular catheter, urinary catheter, surgical operation)." xsd:string
+
+[Term]
+id: distribution
+name: distribution
+is_a: interpretation ! interpretation
+
+[Term]
+id: duration_of_infection
+name: duration of infection
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: effective_reproduction_number
+name: effective reproduction number
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Not all contacts will become infected and the average number of secondary cases per infectious case will be lower than the basic reproduction number. The effective reproductive number (R) is the average number of secondary cases per infectious case in a population made up of both susceptible and non-susceptible hosts." xsd:string
+
+[Term]
+id: environmental_risk_factor
+name: environmental risk factor
+is_a: risk_factor ! risk factor
+
+[Term]
+id: epidemic_doubling_time
+name: epidemic doubling time
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Time for a given quantity to double in size or number at a constant growth rate." xsd:string
+
+[Term]
+id: epidemiological_core_concepts
+name: epidemiological core concepts
+is_a: BFO:0000001
+
+[Term]
+id: etiology
+name: etiology
+is_a: interpretation ! interpretation
+
+[Term]
+id: exposed_contacts
+name: exposed contacts
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: exposed_individuals
+name: exposed individuals
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: exposition_interval
+name: exposition interval
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: exposure
+name: exposure
+is_a: BFO:0000015
+is_a: interpretation ! interpretation
+
+[Term]
+id: generation_interval
+name: generation interval
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The time lag from a primary infection to a secondary infection caused by the primary infection." xsd:string
+
+[Term]
+id: growth_rate
+name: growth rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: health_status_indicators
+is_a: other_indicators ! other indicators
+disjoint_from: health_systems_indicators
+
+[Term]
+id: health_systems_indicators
+is_a: other_indicators ! other indicators
+
+[Term]
+id: herd_immunity_threshold
+name: herd immunity threshold
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The proportion of a population that need to be immune in order for an infectious disease to become stable in that community." xsd:string
+
+[Term]
+id: hospital-wide_nosocomial_infection_rate_per_100_admissions
+name: hospital-wide nosocomial infection rate per 100 admissions
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "A hospital-wide nosocomial infection rate/100 admissions for a given period (month, quarter, or year) is commonly calculated. In this rate, a patient who has two infections is actually counted twice." xsd:string
+
+[Term]
+id: hospital-wide_patient_infection_rate_per_100_admissions
+name: hospital-wide patient infection rate per 100 admissions
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Hospital-wide patient infection rate/100 admissions are used to avoid the pitfall of multiple infections in the same patient. This rate may be calculated for a given period: month, quarter, and year. In this rate, a patient with two infections is counted only once." xsd:string
+
+[Term]
+id: hospitalization_rate
+name: hospitalization rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Proportion of confirmed cases that were hospitalized." xsd:string
+
+[Term]
+id: host_risk_factor
+name: host risk factor
+is_a: risk_factor ! risk factor
+
+[Term]
+id: incidence_of_sever_outcomes
+name: incidence of sever outcomes
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: infection_fatality_rate
+name: infection fatality rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Represents the proportion of deaths among all infected individuals, including all asymptomatic and undiagnosed subjects." xsd:string
+
+[Term]
+id: infectious_process
+name: infectious process
+is_a: BFO:0000015
+
+[Term]
+id: initial_exposed_case
+name: initial exposed case
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: initial_infection_case
+name: initial infection case
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: interpretation
+name: interpretation
+is_a: epidemiological_core_concepts ! epidemiological core concepts
+
+[Term]
+id: length_of_intensive_care_unit_stay
+name: length of icu stay
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: line_of_infection
+name: line of infection
+is_a: descriptive_epidemiology ! descriptive epidemiology
+
+[Term]
+id: male-to-female_ratio
+name: male-to-female ratio
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Male-to-female ratio of confirmed case-patients" xsd:string
+
+[Term]
+id: median_age_of_cases
+name: median age of cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: median_age_of_cases_died
+name: median age of cases died
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: median_age_of_cases_hospitalized
+name: median age of cases hospitalized
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: new_daily_case_rates
+name: new daily case rates
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: new_daily_cases
+name: new daily cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: new_daily_death_rates
+name: new daily death rates
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: non-pharmaceutical_interventions
+name: non-pharmaceutical interventions
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_active_cases
+name: number of active cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_by_testing
+name: number of cases by testing
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_currently_in_hospital
+name: number of cases currently in hospital
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_currently_in_icu
+name: number of cases currently in icu
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_exposed_by_international_travel
+name: number of cases exposed by international travel
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_exposed_by_local_one_or_cluster_case
+name: number of cases exposed by local (one or cluster) case
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_exposed_by_local_unknown_exposure
+name: number of cases exposed by local unknown exposure
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_hospitalized_this_week
+name: number of cases hospitalized this week
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_removed_from_isolation_this_week
+name: number of cases removed from isolation this week
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_with_exposure_events
+name: number of cases with exposure events
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_with_mild_symptoms
+name: number of cases with mild symptoms
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_with_missing_exposure_information
+name: number of cases with missing exposure information
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_with_no_symptoms
+name: number of cases with no symptoms
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_cases_with_school_exposure_events
+name: number of cases with school exposure events
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_deaths_new_this_week
+name: number of deaths new this week
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_schools_with_exposure_events
+name: number of schools with exposure events
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_tested_specimens
+name: number of tested specimens
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: number_of_tests
+name: number of tests
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: odds_ratio_for_being_an_infected_contact
+name: odds ratio for being an infected contact
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: onset_of_symptom_to_hospitalization
+name: onset of symptom to hospitalization
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: opportunity
+name: opportunity
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Number of daily contacts the infected person has; average number of opportunities a person has to spread the infection each day the person is infectious." xsd:string
+
+[Term]
+id: other_indicators
+name: other indicators
+is_a: BFO:0000001
+
+[Term]
+id: per_capita_mobility
+name: per capita mobility
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percent_daily_change
+name: percent daily change
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Indicates epidemic growth rate as the median percent change in daily numbers of new cases." xsd:string
+
+[Term]
+id: percent_increase_in_mortality
+name: percent increase in mortality
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_cases_died
+name: percentage cases died
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_cases_female_sex
+name: percentage cases female sex
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_cases_removed
+name: percentage cases removed
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_of_asymptomatic_of_confirmed_cases
+name: percentage of asymptomatic of confirmed cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_of_cases
+name: percentage of cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_of_cases_icu
+name: percentage of cases icu
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_of_cases_which_are_detected
+name: percentage of cases which are detected
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: percentage_of_laboratory_findings
+name: percentage of laboratory findings
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: period_from_infectious_to_confirmed
+name: period from infectious to confirmed
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: points_of_interest
+name: points of interest (pois)
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Number of points of interets within a geographical area." xsd:string
+
+[Term]
+id: positive_contacts
+name: positive contacts
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: predictive_value_positive
+name: predictive value positive (pvp)
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The proportion of reported cases that actually have the health-related event under surveillance." xsd:string
+
+[Term]
+id: prevalence_of_comorbidities_cases
+name: prevalence of comorbidities cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: prevalence_of_sars-cov-2_seropositivity
+name: prevalence of sars-cov-2 seropositivity
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: proportion_of_cases_attributed_to_travel
+name: proportion of cases attributed to travel
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: protection_rate
+name: protection rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: quantitative_parameters
+name: quantitative quality
+is_a: BFO:0000019
+relationship: IAO:0000136 APOLLO_SV:00000296 ! is about case
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+
+[Term]
+id: quarantined_cases
+name: quarantined cases
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Confirmed and infected cases under quarantine." xsd:string
+
+[Term]
+id: rate_cases_by_testing
+name: rate cases by testing
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Percent of positive specimens." xsd:string
+
+[Term]
+id: rate_of_cases_with_at_least_one_comorbidity
+name: rate of cases with at least one comorbidity
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: rate_of_community_transmission
+name: rate of community transmission
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: rate_of_infectious_contacts
+name: rate of infectious contacts
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: relative_change_in_new_infections
+name: relative change in new infections
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: reproductive_rate
+name: reproductive rate
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "Average number of cases that will result from an index case." xsd:string
+
+[Term]
+id: risk_factor
+name: risk factor
+is_a: interpretation ! interpretation
+
+[Term]
+id: risk_factors_indicators
+is_a: health_status_indicators
+disjoint_from: service_coverage_indicators
+
+[Term]
+id: secondary_attack_rate
+name: secondary attack rate
+is_a: quantitative_parameters ! quantitative quality
+relationship: IAO:0000136 APOLLO_SV:00000296 ! is about case
+relationship: IAO:0000136 IDO:0000458 ! is about contagiousness
+relationship: IAO:0000136 IDO:0000466 ! is about virulence
+relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
+property_value: http://purl.org/dc/terms/description "Number of exposed persons developing the disease within the range of incubation period following exposure to a primary case." xsd:string
+
+[Term]
+id: serial_interval
+name: serial interval
+is_a: quantitative_parameters ! quantitative quality
+property_value: http://purl.org/dc/terms/description "The time interval between symptom onset in a primary case and a secondary case, which is considered a reasonable approximation of the generation interval and is more practical to observe" xsd:string
+
+[Term]
+id: service_coverage_indicators
+is_a: health_status_indicators
+
+[Term]
+id: susceptible_individuals
+name: susceptible individuals
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: suspected_cases
+name: suspected cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: testing_rate
+name: testing rate
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: total_number_of_cases_ever_hospitalized
+name: total number of cases ever hospitalized
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: total_number_of_cases_removed_from_isolation
+name: total number of cases removed from isolation
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: undetected_cases
+name: undetected cases
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: untraceable_contacts
+name: untraceable contacts
+is_a: quantitative_parameters ! quantitative quality
+
+[Term]
+id: weighted_prevalence
+name: weighted prevalence
+is_a: quantitative_parameters ! quantitative quality
+
+[Typedef]
+id: BFO:0000054
+name: realized in
+domain: BFO:0000017
+range: BFO:0000015
+
+[Typedef]
+id: IAO:0000136
+name: is about
+
+[Typedef]
+id: IAO:0000219
+name: denotes
+is_a: IAO:0000136 ! is about
+
+[Typedef]
+id: RO:0000057
+name: has participant
+
+[Typedef]
+id: RO:0000059
+name: concretizes
+domain: BFO:0000020
+range: BFO:0000031
+
+[Typedef]
+id: RO:0000086
+name: has quality
+range: BFO:0000019
+
+[Typedef]
+id: RO:0000087
+name: has role
+domain: BFO:0000004
+range: BFO:0000023
+
+[Typedef]
+id: RO:0002234
+name: has output
+domain: BFO:0000015
+range: IAO:0000030 ! information content entity
+
+[Typedef]
+id: RO:0002351
+name: has member
+domain: OBI:0000181 ! population
+range: NCBITaxon:9606 ! person
+
+[Typedef]
+id: RO:0002463
+name: target participant in
+
+[Typedef]
+id: RO:0002536
+name: has unit
+
+[Typedef]
+id: SIO:000011
+name: is attribute of
+
+[Typedef]
+id: caused_by
+name: caused by
+domain: BFO:0000015
+range: BFO:0000015
+
+[Typedef]
+id: has_left_time_boundary
+name: has left time boundary
+range: Left_time_boundary ! left time boundary
+is_functional: true
+is_inverse_functional: true
+inverse_of: left_boundary_of ! left boundary of
+
+[Typedef]
+id: has_right_time_boundary
+name: has right time boundary
+range: Right_time_boundary ! right time boundary
+is_functional: true
+is_inverse_functional: true
+inverse_of: right_boundary_of ! right boundary of
+
+[Typedef]
+id: http://purl.obolibrary.org/obo/has_confidence_level
+name: has confidence level
+range: STATO:0000196 ! confidence interval
+
+[Typedef]
+id: left_boundary_of
+name: left boundary of
+is_functional: true
+is_inverse_functional: true
+is_a: time_boundary_of ! time boundary of
+
+[Typedef]
+id: projects_to
+name: projects to
+property_value: http://purl.org/dc/terms/description "Links an entity to its temporal extension.\nEntities which are in time are related to the corresponding temporal regions by projects to. Moreover, entities related to others which are in time may likewise project to temporal regions.\n[FL, 2008-02-28]" xsd:string
+range: Time ! time
+is_functional: true
+
+[Typedef]
+id: right_boundary_of
+name: right boundary of
+is_functional: true
+is_inverse_functional: true
+is_a: time_boundary_of ! time boundary of
+
+[Typedef]
+id: time_boundary_of
+name: time boundary of
+domain: Time_boundary ! time boundary
+range: Temporal_region ! temporal region
+is_functional: true
+

--- a/owl/cemo.obo
+++ b/owl/cemo.obo
@@ -1,6 +1,5 @@
 format-version: 1.2
 data-version: releases/16-05-2021
-import: http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl
 ontology: cemo
 property_value: http://purl.org/dc/elements/1.1/contributor "Elena de la Calle" xsd:string
 property_value: http://purl.org/dc/elements/1.1/contributor https://orcid.org/0000-0001-8149-5890 xsd:string
@@ -16,7 +15,7 @@ property_value: http://purl.org/dc/terms/license https://creativecommons.org/lic
 property_value: http://purl.org/dc/terms/title "COVID-19 Epidemiology and Monitoring Ontology (CEMO)" xsd:string
 property_value: IAO:0000119 "The COVID-19 Epidemiology and Monitoring Ontology (CEMO) provides a model for describing, sharing and integrating of COVID-19 epidemiological data for outbreak monitoring and research." xsd:string
 property_value: owl:versionInfo "16-05-2021" xsd:string
-owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000449>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000008>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000015>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/COVOC_0010003>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/GSSO_006827>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000463>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000467>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000482>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000484>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000511>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000519>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0001343>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_9606>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164332>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164607>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C17734>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000052>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000064>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/PATO_0001415>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000088>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000134>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000182>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000245>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000412>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000414>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000424>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cluster_size>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#daily_deaths>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#generation_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infectious_process>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tests>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#opportunity>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#points_of_interest>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#positive_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#protection_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#serial_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#suspected_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#testing_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence>))\nDeclaration(Class(<http://purl.unep.org/sdg/SDGIO_00020030>))\nDeclaration(Class(<http://www.ebi.ac.uk/efo/EFO_0004804>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Chronoid>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary>))\nDeclaration(Class(<http://www.orpha.net/ORDO/Orphanet_409966>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000057>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/cemo.owl#caused_by>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#projects_to>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of>))\n\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000002> (basic reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> (infectious period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> (quarantine period)\n\n\n# Class: <http://purl.obolibrary.org/obo/COVOC_0010003> (confirmed cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/GSSO_006827> (fertility rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000463> (transmission probability)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000467> (susceptibility)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000482> (incidence proportion)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000484> (infection incidence rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000511> (infected population)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000519> (incubation period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0000519> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0001343> (latency period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0001343> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164332> (sequence identity of sample)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164607> (gene sequence identity)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C17734> (at-risk population)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000052> (incidence proportion ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000064> (period prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/PATO_0001415> (morbidity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000088> (study group population size)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000134> (diagnostic specificity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000182> (odds ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000245> (relative risk)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000412> (prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000414> (mortality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000424> (risk difference)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> (attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> (average daily number of new infections generated per case (rt))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> (average rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> (case fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> (cluster size)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> (critical vaccination coverage)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> (cumulative case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> (cumulative cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> (cumulative death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> (cumulative excess mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> (daily deaths)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> (device-specific rates and procedure-specific rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> (duration of infection)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> (effective reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> (exposed contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> (generation interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> (hospital-wide nosocomial infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> (hospital-wide patient infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> (infection fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> (initial exposed case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> (initial infection case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> (length of icu stay)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> (new daily case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> (new daily cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> (new daily death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> (non-pharmaceutical interventions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> (number of cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> (number of cases with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> (number of cases with school exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> (number of schools with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> (number of tested specimens)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> (number of tests)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#opportunity> (opportunity)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> (per capita mobility)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> (percent daily change)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> (percent increase in mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> (percentage of cases which are detected)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> (percentage of laboratory findings)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> (period from infectious to confirmed)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> (points of interest (pois))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> (positive contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> (proportion of cases attributed to travel)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> (protection rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> (quantitative quality)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> (rate cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> (rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> (relative change in new infections)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> (reproductive rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> (secondary attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> (serial interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> (suspected cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> (testing rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> (weighted prevalence)\n\n\n# Class: <http://purl.unep.org/sdg/SDGIO_00020030> (neonatal mortality rate)\n\n\n# Class: <http://www.ebi.ac.uk/efo/EFO_0004804> (birth rate)\n\n\n# Class: <http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> (time boundary)\n\nEquivalentClasses(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> ObjectSomeValuesFrom(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of> <http://purl.obolibrary.org/obo/BFO_0000008>))\n\n# Class: <http://www.orpha.net/ORDO/Orphanet_409966> (point prevalence)\n\n\n\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C164332> <http://purl.obolibrary.org/obo/NCIT_C164607> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\n)
+owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/APOLLO_SV_00000449>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000001>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000008>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/BFO_0000015>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/COVOC_0010003>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/GSSO_006827>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000463>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000467>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000482>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000484>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000511>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0000519>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/IDO_0001343>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCBITaxon_9606>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164332>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C164607>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/NCIT_C17734>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000052>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/OBCS_0000064>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/PATO_0001415>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000088>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000134>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000182>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000245>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000412>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000414>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/STATO_0000424>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cluster_size>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#daily_deaths>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#generation_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#infectious_process>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#number_of_tests>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#opportunity>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#points_of_interest>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#positive_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#protection_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#serial_interval>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#suspected_cases>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#testing_rate>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence>))\nDeclaration(Class(<http://purl.unep.org/sdg/SDGIO_00020030>))\nDeclaration(Class(<http://www.ebi.ac.uk/efo/EFO_0004804>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Chronoid>))\nDeclaration(Class(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary>))\nDeclaration(Class(<http://www.orpha.net/ORDO/Orphanet_409966>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000057>))\nDeclaration(ObjectProperty(<http://purl.obolibrary.org/obo/cemo.owl#caused_by>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#projects_to>))\nDeclaration(ObjectProperty(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of>))\nDeclaration(AnnotationProperty(<http://purl.obolibrary.org/obo/BFO_0000179>))\nDeclaration(AnnotationProperty(<http://purl.obolibrary.org/obo/BFO_0000180>))\n############################\n#   Annotation Properties\n############################\n\n# Annotation Property: <http://purl.obolibrary.org/obo/BFO_0000179> (BFO OWL specification label)\n\nSubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/BFO_0000179> rdfs:label)\n\n# Annotation Property: <http://purl.obolibrary.org/obo/BFO_0000180> (BFO CLIF specification label)\n\nSubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/BFO_0000180> rdfs:label)\n\n\n\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000002> (basic reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> (infectious period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/APOLLO_SV_00000140> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> (quarantine period)\n\n\n# Class: <http://purl.obolibrary.org/obo/BFO_0000001> (entity)\n\nSubClassOf(<http://purl.obolibrary.org/obo/BFO_0000001> owl:Thing)\n\n# Class: <http://purl.obolibrary.org/obo/COVOC_0010003> (confirmed cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/GSSO_006827> (fertility rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000463> (transmission probability)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000467> (susceptibility)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000482> (incidence proportion)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000484> (infection incidence rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000511> (infected population)\n\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0000519> (incubation period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0000519> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/IDO_0001343> (latency period)\n\nSubClassOf(<http://purl.obolibrary.org/obo/IDO_0001343> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164332> (sequence identity of sample)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C164607> (gene sequence identity)\n\n\n# Class: <http://purl.obolibrary.org/obo/NCIT_C17734> (at-risk population)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000052> (incidence proportion ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/OBCS_0000064> (period prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/PATO_0001415> (morbidity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000088> (study group population size)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000134> (diagnostic specificity)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000182> (odds ratio)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000245> (relative risk)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000412> (prevalence)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000414> (mortality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/STATO_0000424> (risk difference)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> (attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> (average daily number of new infections generated per case (rt))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> (average rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> (case fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> (cluster size)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> (critical vaccination coverage)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> (cumulative case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> (cumulative cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> (cumulative death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> (cumulative excess mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> (daily deaths)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> (device-specific rates and procedure-specific rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> (duration of infection)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> (effective reproduction number)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> (exposed contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> (generation interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> (hospital-wide nosocomial infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> (hospital-wide patient infection rate per 100 admissions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> (infection fatality rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> (initial exposed case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> (initial infection case)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> (length of icu stay)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> (new daily case rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> (new daily cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> (new daily death rates)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> (non-pharmaceutical interventions)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> (number of cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> (number of cases with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> (number of cases with school exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> (number of schools with exposure events)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> (number of tested specimens)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> (number of tests)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#opportunity> (opportunity)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> (per capita mobility)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> (percent daily change)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> (percent increase in mortality)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> (percentage of cases which are detected)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> (percentage of laboratory findings)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> (period from infectious to confirmed)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> (points of interest (pois))\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> (positive contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> (proportion of cases attributed to travel)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> (protection rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> (quantitative quality)\n\nSubClassOf(<http://purl.obolibrary.org/obo/cemo.owl#quantitative_parameters> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>) ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/cemo.owl#caused_by> <http://purl.obolibrary.org/obo/cemo.owl#infectious_process>) ObjectExactCardinality(1 <http://www.onto-med.de/ontologies/gfo.owl#projects_to> <http://www.onto-med.de/ontologies/gfo.owl#Chronoid>)))\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> (rate cases by testing)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> (rate of infectious contacts)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> (relative change in new infections)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> (reproductive rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> (secondary attack rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> (serial interval)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> (suspected cases)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> (testing rate)\n\n\n# Class: <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> (weighted prevalence)\n\n\n# Class: <http://purl.unep.org/sdg/SDGIO_00020030> (neonatal mortality rate)\n\n\n# Class: <http://www.ebi.ac.uk/efo/EFO_0004804> (birth rate)\n\n\n# Class: <http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> (time boundary)\n\nEquivalentClasses(<http://www.onto-med.de/ontologies/gfo.owl#Time_boundary> ObjectSomeValuesFrom(<http://www.onto-med.de/ontologies/gfo.owl#time_boundary_of> <http://purl.obolibrary.org/obo/BFO_0000008>))\n\n# Class: <http://www.orpha.net/ORDO/Orphanet_409966> (point prevalence)\n\n\n\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C164332> <http://purl.obolibrary.org/obo/NCIT_C164607> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_excess_mortality> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percent_increase_in_mortality> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_laboratory_findings> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/COVOC_0010003> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000134> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cluster_size> <http://purl.obolibrary.org/obo/cemo.owl#critical_vaccination_coverage> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#device-specific_rates_and_procedure-specific_rates> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#exposed_contacts> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_nosocomial_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#hospital-wide_patient_infection_rate_per_100_admissions> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#length_of_intensive_care_unit_stay> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#non-pharmaceutical_interventions> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#per_capita_mobility> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#percentage_of_cases_which_are_detected> <http://purl.obolibrary.org/obo/cemo.owl#period_from_infectious_to_confirmed> <http://purl.obolibrary.org/obo/cemo.owl#points_of_interest> <http://purl.obolibrary.org/obo/cemo.owl#positive_contacts> <http://purl.obolibrary.org/obo/cemo.owl#proportion_of_cases_attributed_to_travel> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#relative_change_in_new_infections> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#suspected_cases> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.obolibrary.org/obo/cemo.owl#weighted_prevalence> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#average_daily_number_of_new_infections_generated_per_case_rt> <http://purl.obolibrary.org/obo/cemo.owl#average_rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_cases> <http://purl.obolibrary.org/obo/cemo.owl#cumulative_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#daily_deaths> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_case_rates> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_cases> <http://purl.obolibrary.org/obo/cemo.owl#new_daily_death_rates> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_cases_with_school_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_schools_with_exposure_events> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tested_specimens> <http://purl.obolibrary.org/obo/cemo.owl#number_of_tests> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#percent_daily_change> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#rate_cases_by_testing> <http://purl.obolibrary.org/obo/cemo.owl#rate_of_infectious_contacts> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.obolibrary.org/obo/cemo.owl#testing_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/APOLLO_SV_00000002> <http://purl.obolibrary.org/obo/APOLLO_SV_00000140> <http://purl.obolibrary.org/obo/APOLLO_SV_00000449> <http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000463> <http://purl.obolibrary.org/obo/IDO_0000467> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/IDO_0000511> <http://purl.obolibrary.org/obo/IDO_0000519> <http://purl.obolibrary.org/obo/IDO_0001343> <http://purl.obolibrary.org/obo/NCIT_C17734> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#duration_of_infection> <http://purl.obolibrary.org/obo/cemo.owl#effective_reproduction_number> <http://purl.obolibrary.org/obo/cemo.owl#generation_interval> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#initial_exposed_case> <http://purl.obolibrary.org/obo/cemo.owl#initial_infection_case> <http://purl.obolibrary.org/obo/cemo.owl#opportunity> <http://purl.obolibrary.org/obo/cemo.owl#protection_rate> <http://purl.obolibrary.org/obo/cemo.owl#reproductive_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#serial_interval> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\nDisjointClasses(<http://purl.obolibrary.org/obo/GSSO_006827> <http://purl.obolibrary.org/obo/IDO_0000482> <http://purl.obolibrary.org/obo/IDO_0000484> <http://purl.obolibrary.org/obo/OBCS_0000052> <http://purl.obolibrary.org/obo/OBCS_0000064> <http://purl.obolibrary.org/obo/PATO_0001415> <http://purl.obolibrary.org/obo/STATO_0000088> <http://purl.obolibrary.org/obo/STATO_0000182> <http://purl.obolibrary.org/obo/STATO_0000245> <http://purl.obolibrary.org/obo/STATO_0000412> <http://purl.obolibrary.org/obo/STATO_0000414> <http://purl.obolibrary.org/obo/STATO_0000424> <http://purl.obolibrary.org/obo/cemo.owl#attack_rate> <http://purl.obolibrary.org/obo/cemo.owl#case_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#infection_fatality_rate> <http://purl.obolibrary.org/obo/cemo.owl#secondary_attack_rate> <http://purl.unep.org/sdg/SDGIO_00020030> <http://www.ebi.ac.uk/efo/EFO_0004804> <http://www.orpha.net/ORDO/Orphanet_409966>)\n)
 
 [Term]
 id: APOLLO_SV:00000002
@@ -73,17 +72,596 @@ is_a: quantitative_parameters ! quantitative quality
 property_value: http://purl.org/dc/terms/description "A data item that is the output of some infection case count." xsd:string
 
 [Term]
+id: BFO:0000001
+name: entity
+property_value: BFO:0000179 "entity" xsd:string
+property_value: BFO:0000180 "Entity" xsd:string
+property_value: IAO:0000112 "Julius Caesar" xsd:string
+property_value: IAO:0000112 "the Second World War" xsd:string
+property_value: IAO:0000112 "Verdi’s Requiem" xsd:string
+property_value: IAO:0000112 "your body mass index" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81" xsd:string
+property_value: IAO:0000116 "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000004", comment="per discussion with Barry Smith", http://www.w3.org/2000/01/rdf-schema#seeAlso="http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"}
+property_value: IAO:0000600 "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/001-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000002
+name: continuant
+is_a: BFO:0000001 ! entity
+disjoint_from: BFO:0000003 ! occurrent
+property_value: BFO:0000179 "continuant" xsd:string
+property_value: BFO:0000180 "Continuant" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240" xsd:string
+property_value: IAO:0000116 "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000007"}
+property_value: IAO:0000600 "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/008-002"}
+property_value: IAO:0000601 "if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/126-001"}
+property_value: IAO:0000601 "if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/009-002"}
+property_value: IAO:0000601 "if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/011-002"}
+property_value: IAO:0000602 "(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/009-002"}
+property_value: IAO:0000602 "(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/126-001"}
+property_value: IAO:0000602 "(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/008-002"}
+property_value: IAO:0000602 "(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/011-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000003
+name: occurrent
+is_a: BFO:0000001 ! entity
+property_value: BFO:0000179 "occurrent" xsd:string
+property_value: BFO:0000180 "Occurrent" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players." xsd:string
+property_value: IAO:0000116 "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000006", comment="per discussion with Barry Smith"}
+property_value: IAO:0000116 "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000012"}
+property_value: IAO:0000600 "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/077-002"}
+property_value: IAO:0000601 "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
+property_value: IAO:0000601 "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
+property_value: IAO:0000602 "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
+property_value: IAO:0000602 "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000004
+name: independent continuant
+def: "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/017-002"}
+is_a: BFO:0000002 ! continuant
+disjoint_from: BFO:0000020 ! specifically dependent continuant
+disjoint_from: BFO:0000031 ! generically dependent continuant
+property_value: BFO:0000179 "ic" xsd:string
+property_value: BFO:0000180 "IndependentContinuant" xsd:string
+property_value: IAO:0000112 "a chair" xsd:string
+property_value: IAO:0000112 "a heart" xsd:string
+property_value: IAO:0000112 "a leg" xsd:string
+property_value: IAO:0000112 "a molecule" xsd:string
+property_value: IAO:0000112 "a spatial region" xsd:string
+property_value: IAO:0000112 "an atom" xsd:string
+property_value: IAO:0000112 "an orchestra." xsd:string
+property_value: IAO:0000112 "an organism" xsd:string
+property_value: IAO:0000112 "the bottom right portion of a human torso" xsd:string
+property_value: IAO:0000112 "the interior of your mouth" xsd:string
+property_value: IAO:0000601 "For any independent continuant b and any time t there is some spatial region r such that b is located_in r at t. (axiom label in BFO2 Reference: [134-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/134-001"}
+property_value: IAO:0000601 "For every independent continuant b and time t during the region of time spanned by its life, there are entities which s-depends_on b during t. (axiom label in BFO2 Reference: [018-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/018-002"}
+property_value: IAO:0000602 "(forall (x t) (if (and (IndependentContinuant x) (existsAt x t)) (exists (y) (and (Entity y) (specificallyDependsOnAt y x t))))) // axiom label in BFO2 CLIF: [018-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/018-002"}
+property_value: IAO:0000602 "(forall (x t) (if (IndependentContinuant x) (exists (r) (and (SpatialRegion r) (locatedInAt x r t))))) // axiom label in BFO2 CLIF: [134-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/134-001"}
+property_value: IAO:0000602 "(iff (IndependentContinuant a) (and (Continuant a) (not (exists (b t) (specificallyDependsOnAt a b t))))) // axiom label in BFO2 CLIF: [017-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/017-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000006
+name: spatial region
+is_a: BFO:0000141 ! immaterial entity
+disjoint_from: BFO:0000029 ! site
+disjoint_from: BFO:0000140 ! continuant fiat boundary
+property_value: BFO:0000179 "s-region" xsd:string
+property_value: BFO:0000180 "SpatialRegion" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Spatial regions do not participate in processes." xsd:string
+property_value: IAO:0000116 "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000002", comment="per discussion with Barry Smith"}
+property_value: IAO:0000600 "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
+property_value: IAO:0000601 "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
+property_value: IAO:0000602 "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
+property_value: IAO:0000602 "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000008
+name: temporal region
+is_a: BFO:0000003 ! occurrent
+disjoint_from: BFO:0000011 ! spatiotemporal region
+disjoint_from: BFO:0000015 ! process
+disjoint_from: BFO:0000035 ! process boundary
+property_value: BFO:0000179 "t-region" xsd:string
+property_value: BFO:0000180 "TemporalRegion" xsd:string
+property_value: IAO:0000116 "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000003", comment="per discussion with Barry Smith"}
+property_value: IAO:0000600 "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/100-001"}
+property_value: IAO:0000601 "All parts of temporal regions are temporal regions. (axiom label in BFO2 Reference: [101-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/101-001"}
+property_value: IAO:0000601 "Every temporal region t is such that t occupies_temporal_region t. (axiom label in BFO2 Reference: [119-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/119-002"}
+property_value: IAO:0000602 "(forall (r) (if (TemporalRegion r) (occupiesTemporalRegion r r))) // axiom label in BFO2 CLIF: [119-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/119-002"}
+property_value: IAO:0000602 "(forall (x y) (if (and (TemporalRegion x) (occurrentPartOf y x)) (TemporalRegion y))) // axiom label in BFO2 CLIF: [101-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/101-001"}
+property_value: IAO:0000602 "(forall (x) (if (TemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [100-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/100-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000009
+name: two-dimensional spatial region
+is_a: BFO:0000006 ! spatial region
+disjoint_from: BFO:0000028 ! three-dimensional spatial region
+property_value: BFO:0000179 "2d-s-region" xsd:string
+property_value: BFO:0000180 "TwoDimensionalSpatialRegion" xsd:string
+property_value: IAO:0000112 "an infinitely thin plane in space." xsd:string
+property_value: IAO:0000112 "the surface of a sphere-shaped part of space" xsd:string
+property_value: IAO:0000600 "A two-dimensional spatial region is a spatial region that is of two dimensions. (axiom label in BFO2 Reference: [039-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/039-001"}
+property_value: IAO:0000602 "(forall (x) (if (TwoDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [039-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/039-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000011
+name: spatiotemporal region
+is_a: BFO:0000003 ! occurrent
+property_value: BFO:0000179 "st-region" xsd:string
+property_value: BFO:0000180 "SpatiotemporalRegion" xsd:string
+property_value: IAO:0000112 "the spatiotemporal region occupied by a human life" xsd:string
+property_value: IAO:0000112 "the spatiotemporal region occupied by a process of cellular meiosis." xsd:string
+property_value: IAO:0000112 "the spatiotemporal region occupied by the development of a cancer tumor" xsd:string
+property_value: IAO:0000600 "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/095-001"}
+property_value: IAO:0000601 "All parts of spatiotemporal regions are spatiotemporal regions. (axiom label in BFO2 Reference: [096-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/096-001"}
+property_value: IAO:0000601 "Each spatiotemporal region at any time t projects_onto some spatial region at t. (axiom label in BFO2 Reference: [099-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/099-001"}
+property_value: IAO:0000601 "Each spatiotemporal region projects_onto some temporal region. (axiom label in BFO2 Reference: [098-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/098-001"}
+property_value: IAO:0000601 "Every spatiotemporal region occupies_spatiotemporal_region itself." xsd:string
+property_value: IAO:0000601 "Every spatiotemporal region s is such that s occupies_spatiotemporal_region s. (axiom label in BFO2 Reference: [107-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/107-002"}
+property_value: IAO:0000602 "(forall (r) (if (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion r r))) // axiom label in BFO2 CLIF: [107-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/107-002"}
+property_value: IAO:0000602 "(forall (x t) (if (SpatioTemporalRegion x) (exists (y) (and (SpatialRegion y) (spatiallyProjectsOntoAt x y t))))) // axiom label in BFO2 CLIF: [099-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/099-001"}
+property_value: IAO:0000602 "(forall (x y) (if (and (SpatioTemporalRegion x) (occurrentPartOf y x)) (SpatioTemporalRegion y))) // axiom label in BFO2 CLIF: [096-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/096-001"}
+property_value: IAO:0000602 "(forall (x) (if (SpatioTemporalRegion x) (exists (y) (and (TemporalRegion y) (temporallyProjectsOnto x y))))) // axiom label in BFO2 CLIF: [098-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/098-001"}
+property_value: IAO:0000602 "(forall (x) (if (SpatioTemporalRegion x) (Occurrent x))) // axiom label in BFO2 CLIF: [095-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/095-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
 id: BFO:0000015
+name: process
+def: "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/083-003"}
+is_a: BFO:0000003 ! occurrent
 equivalent_to: Process ! process
+property_value: BFO:0000179 "process" xsd:string
+property_value: BFO:0000180 "Process" xsd:string
+property_value: IAO:0000112 "a process of cell-division, \\ a beating of the heart" xsd:string
+property_value: IAO:0000112 "a process of meiosis" xsd:string
+property_value: IAO:0000112 "a process of sleeping" xsd:string
+property_value: IAO:0000112 "the course of a disease" xsd:string
+property_value: IAO:0000112 "the flight of a bird" xsd:string
+property_value: IAO:0000112 "the life of an organism" xsd:string
+property_value: IAO:0000112 "your process of aging." xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)" xsd:string
+property_value: IAO:0000602 "(iff (Process a) (and (Occurrent a) (exists (b) (properTemporalPartOf b a)) (exists (c t) (and (MaterialEntity c) (specificallyDependsOnAt a c t))))) // axiom label in BFO2 CLIF: [083-003] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/083-003"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000016
+name: disposition
+is_a: BFO:0000017 ! realizable entity
+disjoint_from: BFO:0000023 ! role
+property_value: BFO:0000179 "disposition" xsd:string
+property_value: BFO:0000180 "Disposition" xsd:string
+property_value: IAO:0000112 "an atom of element X has the disposition to decay to an atom of element Y" xsd:string
+property_value: IAO:0000112 "certain people have a predisposition to colon cancer" xsd:string
+property_value: IAO:0000112 "children are innately disposed to categorize objects in certain ways." xsd:string
+property_value: IAO:0000112 "the cell wall is disposed to filter chemicals in endocytosis and exocytosis" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type." xsd:string
+property_value: IAO:0000600 "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
+property_value: IAO:0000601 "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
+property_value: IAO:0000602 "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
+property_value: IAO:0000602 "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000017
+name: realizable entity
+is_a: BFO:0000020 ! specifically dependent continuant
+disjoint_from: BFO:0000019 ! quality
+property_value: BFO:0000179 "realizable" xsd:string
+property_value: BFO:0000180 "RealizableEntity" xsd:string
+property_value: IAO:0000112 "the disposition of this piece of metal to conduct electricity." xsd:string
+property_value: IAO:0000112 "the disposition of your blood to coagulate" xsd:string
+property_value: IAO:0000112 "the function of your reproductive organs" xsd:string
+property_value: IAO:0000112 "the role of being a doctor" xsd:string
+property_value: IAO:0000112 "the role of this boundary to delineate where Utah and Colorado meet" xsd:string
+property_value: IAO:0000600 "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
+property_value: IAO:0000601 "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
+property_value: IAO:0000602 "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
+property_value: IAO:0000602 "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000018
+name: zero-dimensional spatial region
+is_a: BFO:0000006 ! spatial region
+disjoint_from: BFO:0000028 ! three-dimensional spatial region
+property_value: BFO:0000179 "0d-s-region" xsd:string
+property_value: BFO:0000180 "ZeroDimensionalSpatialRegion" xsd:string
+property_value: IAO:0000600 "A zero-dimensional spatial region is a point in space. (axiom label in BFO2 Reference: [037-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/037-001"}
+property_value: IAO:0000602 "(forall (x) (if (ZeroDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [037-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/037-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000019
+name: quality
+is_a: BFO:0000020 ! specifically dependent continuant
+property_value: BFO:0000179 "quality" xsd:string
+property_value: BFO:0000180 "Quality" xsd:string
+property_value: IAO:0000112 "the ambient temperature of this portion of air" xsd:string
+property_value: IAO:0000112 "the color of a tomato" xsd:string
+property_value: IAO:0000112 "the length of the circumference of your waist" xsd:string
+property_value: IAO:0000112 "the mass of this piece of gold." xsd:string
+property_value: IAO:0000112 "the shape of your nose" xsd:string
+property_value: IAO:0000112 "the shape of your nostril" xsd:string
+property_value: IAO:0000600 "a quality is a specifically dependent continuant that, in contrast to roles and dispositions, does not require any further process in order to be realized. (axiom label in BFO2 Reference: [055-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/055-001"}
+property_value: IAO:0000601 "If an entity is a quality at any time that it exists, then it is a quality at every time that it exists. (axiom label in BFO2 Reference: [105-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/105-001"}
+property_value: IAO:0000602 "(forall (x) (if (exists (t) (and (existsAt x t) (Quality x))) (forall (t_1) (if (existsAt x t_1) (Quality x))))) // axiom label in BFO2 CLIF: [105-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/105-001"}
+property_value: IAO:0000602 "(forall (x) (if (Quality x) (SpecificallyDependentContinuant x))) // axiom label in BFO2 CLIF: [055-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/055-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000020
+name: specifically dependent continuant
+def: "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
+is_a: BFO:0000002 ! continuant
+disjoint_from: BFO:0000031 ! generically dependent continuant
+property_value: BFO:0000179 "sdc" xsd:string
+property_value: BFO:0000180 "SpecificallyDependentContinuant" xsd:string
+property_value: IAO:0000112 "of one-sided specifically dependent continuants: the mass of this tomato" xsd:string
+property_value: IAO:0000112 "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates." xsd:string
+property_value: IAO:0000112 "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key" xsd:string
+property_value: IAO:0000112 "the disposition of this fish to decay" xsd:string
+property_value: IAO:0000112 "the function of this heart: to pump blood" xsd:string
+property_value: IAO:0000112 "the mutual dependence of proton donors and acceptors in chemical reactions [79" xsd:string
+property_value: IAO:0000112 "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction" xsd:string
+property_value: IAO:0000112 "the pink color of a medium rare piece of grilled filet mignon at its center" xsd:string
+property_value: IAO:0000112 "the role of being a doctor" xsd:string
+property_value: IAO:0000112 "the shape of this hole." xsd:string
+property_value: IAO:0000112 "the smell of this portion of mozzarella" xsd:string
+property_value: IAO:0000116 "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000005", comment="per discussion with Barry Smith"}
+property_value: IAO:0000602 "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000023
+name: role
+is_a: BFO:0000017 ! realizable entity
+property_value: BFO:0000179 "role" xsd:string
+property_value: BFO:0000180 "Role" xsd:string
+property_value: IAO:0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married." xsd:string
+property_value: IAO:0000112 "the priest role" xsd:string
+property_value: IAO:0000112 "the role of a boundary to demarcate two neighboring administrative territories" xsd:string
+property_value: IAO:0000112 "the role of a building in serving as a military target" xsd:string
+property_value: IAO:0000112 "the role of a stone in marking a property boundary" xsd:string
+property_value: IAO:0000112 "the role of subject in a clinical trial" xsd:string
+property_value: IAO:0000112 "the student role" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives." xsd:string
+property_value: IAO:0000600 "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
+property_value: IAO:0000602 "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000024
+name: fiat object part
+is_a: BFO:0000040 ! material entity
+property_value: BFO:0000179 "fiat-object-part" xsd:string
+property_value: BFO:0000180 "FiatObjectPart" xsd:string
+property_value: IAO:0000112 "or with divisions drawn by cognitive subjects for practical reasons, such as the division of a cake (before slicing) into (what will become) slices (and thus member parts of an object aggregate). However, this does not mean that fiat object parts are dependent for their existence on divisions or delineations effected by cognitive subjects. If, for example, it is correct to conceive geological layers of the Earth as fiat object parts of the Earth, then even though these layers were first delineated in recent times, still existed long before such delineation and what holds of these layers (for example that the oldest layers are also the lowest layers) did not begin to hold because of our acts of delineation.Treatment of material entity in BFOExamples viewed by some as problematic cases for the trichotomy of fiat object part, object, and object aggregate include: a mussel on (and attached to) a rock, a slime mold, a pizza, a cloud, a galaxy, a railway train with engine and multiple carriages, a clonal stand of quaking aspen, a bacterial community (biofilm), a broken femur. Note that, as Aristotle already clearly recognized, such problematic cases – which lie at or near the penumbra of instances defined by the categories in question – need not invalidate these categories. The existence of grey objects does not prove that there are not objects which are black and objects which are white; the existence of mules does not prove that there are not objects which are donkeys and objects which are horses. It does, however, show that the examples in question need to be addressed carefully in order to show how they can be fitted into the proposed scheme, for example by recognizing additional subdivisions [29" xsd:string
+property_value: IAO:0000112 "the division of the brain into regions" xsd:string
+property_value: IAO:0000112 "the division of the planet into hemispheres" xsd:string
+property_value: IAO:0000112 "the dorsal and ventral surfaces of the body" xsd:string
+property_value: IAO:0000112 "the FMA:regional parts of an intact human body." xsd:string
+property_value: IAO:0000112 "the upper and lower lobes of the left lung" xsd:string
+property_value: IAO:0000112 "the Western hemisphere of the Earth" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Most examples of fiat object parts are associated with theoretically drawn divisions" xsd:string
+property_value: IAO:0000600 "b is a fiat object part = Def. b is a material entity which is such that for all times t, if b exists at t then there is some object c such that b proper continuant_part of  c at t and c is demarcated from the remainder of c by a two-dimensional continuant fiat boundary. (axiom label in BFO2 Reference: [027-004])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/027-004"}
+property_value: IAO:0000602 "(forall (x) (if (FiatObjectPart x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y) (and (Object y) (properContinuantPartOfAt x y t)))))))) // axiom label in BFO2 CLIF: [027-004] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/027-004"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000026
+name: one-dimensional spatial region
+is_a: BFO:0000006 ! spatial region
+disjoint_from: BFO:0000028 ! three-dimensional spatial region
+property_value: BFO:0000179 "1d-s-region" xsd:string
+property_value: BFO:0000180 "OneDimensionalSpatialRegion" xsd:string
+property_value: IAO:0000112 "an edge of a cube-shaped portion of space." xsd:string
+property_value: IAO:0000600 "A one-dimensional spatial region is a line or aggregate of lines stretching from one point in space to another. (axiom label in BFO2 Reference: [038-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/038-001"}
+property_value: IAO:0000602 "(forall (x) (if (OneDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [038-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/038-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000027
+name: object aggregate
+is_a: BFO:0000040 ! material entity
+property_value: BFO:0000179 "object-aggregate" xsd:string
+property_value: BFO:0000180 "ObjectAggregate" xsd:string
+property_value: IAO:0000112 "a collection of cells in a blood biobank." xsd:string
+property_value: IAO:0000112 "a swarm of bees is an aggregate of members who are linked together through natural bonds" xsd:string
+property_value: IAO:0000112 "a symphony orchestra" xsd:string
+property_value: IAO:0000112 "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)" xsd:string
+property_value: IAO:0000112 "defined by fiat: the aggregate of members of an organization" xsd:string
+property_value: IAO:0000112 "defined through physical attachment: the aggregate of atoms in a lump of granite" xsd:string
+property_value: IAO:0000112 "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container" xsd:string
+property_value: IAO:0000112 "defined via attributive delimitations such as: the patients in this hospital" xsd:string
+property_value: IAO:0000112 "the aggregate of bearings in a constant velocity axle joint" xsd:string
+property_value: IAO:0000112 "the aggregate of blood cells in your body" xsd:string
+property_value: IAO:0000112 "the nitrogen atoms in the atmosphere" xsd:string
+property_value: IAO:0000112 "the restaurants in Palo Alto" xsd:string
+property_value: IAO:0000112 "your collection of Meissen ceramic plates." xsd:string
+property_value: IAO:0000116 "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000301"}
+property_value: IAO:0000116 "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000011"}
+property_value: IAO:0000116 "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)." xsd:string
+property_value: IAO:0000119 "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000300"}
+property_value: IAO:0000600 "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/025-004"}
+property_value: IAO:0000602 "(forall (x) (if (ObjectAggregate x) (and (MaterialEntity x) (forall (t) (if (existsAt x t) (exists (y z) (and (Object y) (Object z) (memberPartOfAt y x t) (memberPartOfAt z x t) (not (= y z)))))) (not (exists (w t_1) (and (memberPartOfAt w x t_1) (not (Object w)))))))) // axiom label in BFO2 CLIF: [025-004] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/025-004"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000028
+name: three-dimensional spatial region
+is_a: BFO:0000006 ! spatial region
+property_value: BFO:0000179 "3d-s-region" xsd:string
+property_value: BFO:0000180 "ThreeDimensionalSpatialRegion" xsd:string
+property_value: IAO:0000112 "a cube-shaped region of space" xsd:string
+property_value: IAO:0000112 "a sphere-shaped region of space," xsd:string
+property_value: IAO:0000600 "A three-dimensional spatial region is a spatial region that is of three dimensions. (axiom label in BFO2 Reference: [040-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/040-001"}
+property_value: IAO:0000602 "(forall (x) (if (ThreeDimensionalSpatialRegion x) (SpatialRegion x))) // axiom label in BFO2 CLIF: [040-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/040-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000029
+name: site
+is_a: BFO:0000141 ! immaterial entity
+property_value: BFO:0000179 "site" xsd:string
+property_value: BFO:0000180 "Site" xsd:string
+property_value: IAO:0000112 "a hole in the interior of a portion of cheese" xsd:string
+property_value: IAO:0000112 "a rabbit hole" xsd:string
+property_value: IAO:0000112 "an air traffic control region defined in the airspace above an airport" xsd:string
+property_value: IAO:0000112 "Manhattan Canyon)" xsd:string
+property_value: IAO:0000112 "the cockpit of an aircraft" xsd:string
+property_value: IAO:0000112 "the Grand Canyon" xsd:string
+property_value: IAO:0000112 "the hold of a ship" xsd:string
+property_value: IAO:0000112 "the interior of a kangaroo pouch" xsd:string
+property_value: IAO:0000112 "the interior of the trunk of your car" xsd:string
+property_value: IAO:0000112 "the interior of your bedroom" xsd:string
+property_value: IAO:0000112 "the interior of your office" xsd:string
+property_value: IAO:0000112 "the interior of your refrigerator" xsd:string
+property_value: IAO:0000112 "the lumen of your gut" xsd:string
+property_value: IAO:0000112 "the Piazza San Marco" xsd:string
+property_value: IAO:0000112 "your left nostril (a fiat part – the opening – of your left nasal cavity)" xsd:string
+property_value: IAO:0000600 "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/034-002"}
+property_value: IAO:0000602 "(forall (x) (if (Site x) (ImmaterialEntity x))) // axiom label in BFO2 CLIF: [034-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/034-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000030
+name: object
+is_a: BFO:0000040 ! material entity
+property_value: BFO:0000179 "object" xsd:string
+property_value: BFO:0000180 "Object" xsd:string
+property_value: IAO:0000112 "atom" xsd:string
+property_value: IAO:0000112 "cell" xsd:string
+property_value: IAO:0000112 "cells and organisms" xsd:string
+property_value: IAO:0000112 "engineered artifacts" xsd:string
+property_value: IAO:0000112 "grain of sand" xsd:string
+property_value: IAO:0000112 "molecule" xsd:string
+property_value: IAO:0000112 "organelle" xsd:string
+property_value: IAO:0000112 "organism" xsd:string
+property_value: IAO:0000112 "planet" xsd:string
+property_value: IAO:0000112 "solid portions of matter" xsd:string
+property_value: IAO:0000112 "star" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: an object is a maximal causally unified material entity" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting." xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)." xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74" xsd:string
+property_value: IAO:0000600 "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/024-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000031
+name: generically dependent continuant
+def: "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
+is_a: BFO:0000002 ! continuant
+property_value: BFO:0000179 "gdc" xsd:string
+property_value: BFO:0000180 "GenericallyDependentContinuant" xsd:string
+property_value: IAO:0000112 "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity." xsd:string
+property_value: IAO:0000112 "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop" xsd:string
+property_value: IAO:0000112 "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule." xsd:string
+property_value: IAO:0000602 "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000034
+name: function
+is_a: BFO:0000016 ! disposition
+property_value: BFO:0000179 "function" xsd:string
+property_value: BFO:0000180 "Function" xsd:string
+property_value: IAO:0000112 "the function of a hammer to drive in nails" xsd:string
+property_value: IAO:0000112 "the function of a heart pacemaker to regulate the beating of a heart through electricity" xsd:string
+property_value: IAO:0000112 "the function of amylase in saliva to break down starch into sugar" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc." xsd:string
+property_value: IAO:0000600 "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
+property_value: IAO:0000602 "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000035
+name: process boundary
+def: "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/084-001"}
+is_a: BFO:0000003 ! occurrent
 equivalent_to: Event ! event
+property_value: BFO:0000179 "p-boundary" xsd:string
+property_value: BFO:0000180 "ProcessBoundary" xsd:string
+property_value: IAO:0000112 "the boundary between the 2nd and 3rd year of your life." xsd:string
+property_value: IAO:0000601 "Every process boundary occupies_temporal_region a zero-dimensional temporal region. (axiom label in BFO2 Reference: [085-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/085-002"}
+property_value: IAO:0000602 "(forall (x) (if (ProcessBoundary x) (exists (y) (and (ZeroDimensionalTemporalRegion y) (occupiesTemporalRegion x y))))) // axiom label in BFO2 CLIF: [085-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/085-002"}
+property_value: IAO:0000602 "(iff (ProcessBoundary a) (exists (p) (and (Process p) (temporalPartOf a p) (not (exists (b) (properTemporalPartOf b a)))))) // axiom label in BFO2 CLIF: [084-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/084-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000038
+name: one-dimensional temporal region
+is_a: BFO:0000008 ! temporal region
+disjoint_from: BFO:0000148 ! zero-dimensional temporal region
+property_value: BFO:0000179 "1d-t-region" xsd:string
+property_value: BFO:0000180 "OneDimensionalTemporalRegion" xsd:string
+property_value: IAO:0000112 "the temporal region during which a process occurs." xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)." xsd:string
+property_value: IAO:0000600 "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/103-001"}
+property_value: IAO:0000602 "(forall (x) (if (OneDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [103-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/103-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000040
+name: material entity
+is_a: BFO:0000004 ! independent continuant
+disjoint_from: BFO:0000141 ! immaterial entity
+property_value: BFO:0000179 "material" xsd:string
+property_value: BFO:0000180 "MaterialEntity" xsd:string
+property_value: IAO:0000112 "a flame" xsd:string
+property_value: IAO:0000112 "a forest fire" xsd:string
+property_value: IAO:0000112 "a human being" xsd:string
+property_value: IAO:0000112 "a hurricane" xsd:string
+property_value: IAO:0000112 "a photon" xsd:string
+property_value: IAO:0000112 "a puff of smoke" xsd:string
+property_value: IAO:0000112 "a sea wave" xsd:string
+property_value: IAO:0000112 "a tornado" xsd:string
+property_value: IAO:0000112 "an aggregate of human beings." xsd:string
+property_value: IAO:0000112 "an energy wave" xsd:string
+property_value: IAO:0000112 "an epidemic" xsd:string
+property_value: IAO:0000112 "the undetached arm of a human being" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity." xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here." xsd:string
+property_value: IAO:0000600 "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/019-002"}
+property_value: IAO:0000601 "every entity of which a material entity is continuant part is also a material entity. (axiom label in BFO2 Reference: [021-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/021-002"}
+property_value: IAO:0000601 "Every entity which has a material entity as continuant part is a material entity. (axiom label in BFO2 Reference: [020-002])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/020-002"}
+property_value: IAO:0000602 "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt x y t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [021-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/021-002"}
+property_value: IAO:0000602 "(forall (x) (if (and (Entity x) (exists (y t) (and (MaterialEntity y) (continuantPartOfAt y x t)))) (MaterialEntity x))) // axiom label in BFO2 CLIF: [020-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/020-002"}
+property_value: IAO:0000602 "(forall (x) (if (MaterialEntity x) (IndependentContinuant x))) // axiom label in BFO2 CLIF: [019-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/019-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000140
+name: continuant fiat boundary
+def: "b is a continuant fiat boundary = Def. b is an immaterial entity that is of zero, one or two dimensions and does not include a spatial region as part. (axiom label in BFO2 Reference: [029-001])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/029-001"}
+is_a: BFO:0000141 ! immaterial entity
+property_value: BFO:0000179 "cf-boundary" xsd:string
+property_value: BFO:0000180 "ContinuantFiatBoundary" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: a continuant fiat boundary is a boundary of some material entity (for example: the plane separating the Northern and Southern hemispheres; the North Pole), or it is a boundary of some immaterial entity (for example of some portion of airspace). Three basic kinds of continuant fiat boundary can be distinguished (together with various combination kinds [29" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: In BFO 1.1 the assumption was made that the external surface of a material entity such as a cell could be treated as if it were a boundary in the mathematical sense. The new document propounds the view that when we talk about external surfaces of material objects in this way then we are talking about something fiat. To be dealt with in a future version: fiat boundaries at different levels of granularity.More generally, the focus in discussion of boundaries in BFO 2.0 is now on fiat boundaries, which means: boundaries for which there is no assumption that they coincide with physical discontinuities. The ontology of boundaries becomes more closely allied with the ontology of regions." xsd:string
+property_value: IAO:0000116 "Continuant fiat boundary doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the mereological sum of two-dimensional continuant fiat boundary and a one dimensional continuant fiat boundary that doesn't overlap it. The situation is analogous to temporal and spatial regions." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000008"}
+property_value: IAO:0000601 "Every continuant fiat boundary is located at some spatial region at every time at which it exists" xsd:string
+property_value: IAO:0000602 "(iff (ContinuantFiatBoundary a) (and (ImmaterialEntity a) (exists (b) (and (or (ZeroDimensionalSpatialRegion b) (OneDimensionalSpatialRegion b) (TwoDimensionalSpatialRegion b)) (forall (t) (locatedInAt a b t)))) (not (exists (c t) (and (SpatialRegion c) (continuantPartOfAt c a t)))))) // axiom label in BFO2 CLIF: [029-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/029-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000141
+name: immaterial entity
+is_a: BFO:0000004 ! independent continuant
+property_value: BFO:0000179 "immaterial" xsd:string
+property_value: BFO:0000180 "ImmaterialEntity" xsd:string
+property_value: IAO:0000116 "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10" xsd:string
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000142
+name: one-dimensional continuant fiat boundary
+is_a: BFO:0000140 ! continuant fiat boundary
+disjoint_from: BFO:0000146 ! two-dimensional continuant fiat boundary
+disjoint_from: BFO:0000147 ! zero-dimensional continuant fiat boundary
+property_value: BFO:0000179 "1d-cf-boundary" xsd:string
+property_value: BFO:0000180 "OneDimensionalContinuantFiatBoundary" xsd:string
+property_value: IAO:0000112 "all geopolitical boundaries" xsd:string
+property_value: IAO:0000112 "all lines of latitude and longitude" xsd:string
+property_value: IAO:0000112 "The Equator" xsd:string
+property_value: IAO:0000112 "the line separating the outer surface of the mucosa of the lower lip from the outer surface of the skin of the chin." xsd:string
+property_value: IAO:0000112 "the median sulcus of your tongue" xsd:string
+property_value: IAO:0000600 "a one-dimensional continuant fiat boundary is a continuous fiat line whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [032-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/032-001"}
+property_value: IAO:0000602 "(iff (OneDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (OneDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [032-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/032-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000144
+name: process profile
+def: "b is a process_profile =Def. there is some process c such that b process_profile_of c (axiom label in BFO2 Reference: [093-002])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/093-002"}
+is_a: BFO:0000015 ! process
+disjoint_from: BFO:0000182 ! history
+property_value: BFO:0000179 "process-profile" xsd:string
+property_value: BFO:0000180 "ProcessProfile" xsd:string
+property_value: IAO:0000112 "On a somewhat higher level of complexity are what we shall call rate process profiles, which are the targets of selective abstraction focused not on determinate quality magnitudes plotted over time, but rather on certain ratios between these magnitudes and elapsed times. A speed process profile, for example, is represented by a graph plotting against time the ratio of distance covered per unit of time. Since rates may change, and since such changes, too, may have rates of change, we have to deal here with a hierarchy of process profile universals at successive levels" xsd:string
+property_value: IAO:0000112 "One important sub-family of rate process profiles is illustrated by the beat or frequency profiles of cyclical processes, illustrated by the 60 beats per minute beating process of John’s heart, or the 120 beats per minute drumming process involved in one of John’s performances in a rock band, and so on. Each such process includes what we shall call a beat process profile instance as part, a subtype of rate process profile in which the salient ratio is not distance covered but rather number of beat cycles per unit of time. Each beat process profile instance instantiates the determinable universal beat process profile. But it also instantiates multiple more specialized universals at lower levels of generality, selected from   rate process profilebeat process profileregular beat process profile3 bpm beat process profile4 bpm beat process profileirregular beat process profileincreasing beat process profileand so on.In the case of a regular beat process profile, a rate can be assigned in the simplest possible fashion by dividing the number of cycles by the length of the temporal region occupied by the beating process profile as a whole. Irregular process profiles of this sort, for example as identified in the clinic, or in the readings on an aircraft instrument panel, are often of diagnostic significance." xsd:string
+property_value: IAO:0000112 "The simplest type of process profiles are what we shall call ‘quality process profiles’, which are the process profiles which serve as the foci of the sort of selective abstraction that is involved when measurements are made of changes in single qualities, as illustrated, for example, by process profiles of mass, temperature, aortic pressure, and so on." xsd:string
+property_value: IAO:0000600 "b process_profile_of c holds when b proper_occurrent_part_of c& there is some proper_occurrent_part d of c which has no parts in common with b & is mutually dependent on b& is such that b, c and d occupy the same temporal region (axiom label in BFO2 Reference: [094-005])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/094-005"}
+property_value: IAO:0000602 "(forall (x y) (if (processProfileOf x y) (and (properContinuantPartOf x y) (exists (z t) (and (properOccurrentPartOf z y) (TemporalRegion t) (occupiesSpatioTemporalRegion x t) (occupiesSpatioTemporalRegion y t) (occupiesSpatioTemporalRegion z t) (not (exists (w) (and (occurrentPartOf w x) (occurrentPartOf w z))))))))) // axiom label in BFO2 CLIF: [094-005] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/094-005"}
+property_value: IAO:0000602 "(iff (ProcessProfile a) (exists (b) (and (Process b) (processProfileOf a b)))) // axiom label in BFO2 CLIF: [093-002] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/093-002"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000145
+name: relational quality
+def: "b is a relational quality = Def. for some independent continuants c, d and for some time t: b quality_of c at t & b quality_of d at t. (axiom label in BFO2 Reference: [057-001])" [] {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/057-001"}
+is_a: BFO:0000019 ! quality
+property_value: BFO:0000179 "r-quality" xsd:string
+property_value: BFO:0000180 "RelationalQuality" xsd:string
+property_value: IAO:0000112 "a marriage bond, an instance of requited love, an obligation between one person and another." xsd:string
+property_value: IAO:0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married." xsd:string
+property_value: IAO:0000602 "(iff (RelationalQuality a) (exists (b c t) (and (IndependentContinuant b) (IndependentContinuant c) (qualityOfAt a b t) (qualityOfAt a c t)))) // axiom label in BFO2 CLIF: [057-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/057-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000146
+name: two-dimensional continuant fiat boundary
+is_a: BFO:0000140 ! continuant fiat boundary
+property_value: BFO:0000179 "2d-cf-boundary" xsd:string
+property_value: BFO:0000180 "TwoDimensionalContinuantFiatBoundary" xsd:string
+property_value: IAO:0000600 "a two-dimensional continuant fiat boundary (surface) is a self-connected fiat surface whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [033-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/033-001"}
+property_value: IAO:0000602 "(iff (TwoDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (TwoDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [033-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/033-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000147
+name: zero-dimensional continuant fiat boundary
+is_a: BFO:0000140 ! continuant fiat boundary
+property_value: BFO:0000179 "0d-cf-boundary" xsd:string
+property_value: BFO:0000180 "ZeroDimensionalContinuantFiatBoundary" xsd:string
+property_value: IAO:0000112 "the geographic North Pole" xsd:string
+property_value: IAO:0000112 "the point of origin of some spatial coordinate system." xsd:string
+property_value: IAO:0000112 "the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet" xsd:string
+property_value: IAO:0000116 "zero dimension continuant fiat boundaries are not spatial points. Considering the example 'the quadripoint where the boundaries of Colorado, Utah, New Mexico, and Arizona meet' : There are many frames in which that point is zooming through many points in space. Whereas, no matter what the frame, the quadripoint is always in the same relation to the boundaries of Colorado, Utah, New Mexico, and Arizona." xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000001", comment="requested by Melanie Courtot", http://www.w3.org/2000/01/rdf-schema#seeAlso="ZDRnpiIi:TUJ"}
+property_value: IAO:0000600 "a zero-dimensional continuant fiat boundary is a fiat point whose location is defined in relation to some material entity. (axiom label in BFO2 Reference: [031-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/031-001"}
+property_value: IAO:0000602 "(iff (ZeroDimensionalContinuantFiatBoundary a) (and (ContinuantFiatBoundary a) (exists (b) (and (ZeroDimensionalSpatialRegion b) (forall (t) (locatedInAt a b t)))))) // axiom label in BFO2 CLIF: [031-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/031-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
+
+[Term]
+id: BFO:0000148
+name: zero-dimensional temporal region
+is_a: BFO:0000008 ! temporal region
+property_value: BFO:0000179 "0d-t-region" xsd:string
+property_value: BFO:0000180 "ZeroDimensionalTemporalRegion" xsd:string
+property_value: IAO:0000112 "a temporal region that is occupied by a process boundary" xsd:string
+property_value: IAO:0000112 "right now" xsd:string
+property_value: IAO:0000112 "the moment at which a child is born" xsd:string
+property_value: IAO:0000112 "the moment at which a finger is detached in an industrial accident" xsd:string
+property_value: IAO:0000112 "the moment of death." xsd:string
+property_value: IAO:0000118 "temporal instant." xsd:string
+property_value: IAO:0000600 "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/102-001"}
+property_value: IAO:0000602 "(forall (x) (if (ZeroDimensionalTemporalRegion x) (TemporalRegion x))) // axiom label in BFO2 CLIF: [102-001] " xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/102-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000182
+name: history
 name: natural history
+is_a: BFO:0000015 ! process
 is_a: interpretation ! interpretation
+property_value: BFO:0000179 "history" xsd:string
+property_value: BFO:0000180 "History" xsd:string
+property_value: IAO:0000600 "A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])" xsd:string {http://purl.obolibrary.org/obo/IAO_0010000="http://purl.obolibrary.org/obo/bfo/axiom/138-001"}
+property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: COVOC:0010003
@@ -95,8 +673,8 @@ property_value: http://purl.org/dc/terms/description "Any person meeting the lab
 id: Chronoid
 name: chronoid
 is_a: Temporal_region ! temporal region
-relationship: has_left_time_boundary BFO:0000001 {cardinality="1"}
-relationship: has_right_time_boundary BFO:0000001 {cardinality="1"}
+relationship: has_left_time_boundary BFO:0000001 {cardinality="1"} ! entity
+relationship: has_right_time_boundary BFO:0000001 {cardinality="1"} ! entity
 property_value: http://purl.org/dc/terms/description "Chronoids are entities sui generis.\n\nEvery chronoid has exactly two extremal and\ninfinitely many inner time boundaries which are\nequivalently called time-points." xsd:string
 
 [Term]
@@ -138,7 +716,7 @@ is_a: IAO:0000030 ! information content entity
 [Term]
 id: IAO:0000030
 name: information content entity
-is_a: BFO:0000031
+is_a: BFO:0000031 ! generically dependent continuant
 
 [Term]
 id: IAO:0000109
@@ -153,13 +731,13 @@ is_a: IAO:0000030 ! information content entity
 [Term]
 id: IDO:0000425
 name: virulence factor
-is_a: BFO:0000016
+is_a: BFO:0000016 ! disposition
 is_a: interpretation ! interpretation
 
 [Term]
 id: IDO:0000458
 name: contagiousness
-is_a: BFO:0000016
+is_a: BFO:0000016 ! disposition
 is_a: interpretation ! interpretation
 
 [Term]
@@ -205,7 +783,7 @@ property_value: http://purl.org/dc/terms/description "It is the number of new ev
 [Term]
 id: IDO:0000509
 name: organism population
-is_a: BFO:0000027
+is_a: BFO:0000027 ! object aggregate
 equivalent_to: OBI:0000181 ! population
 
 [Term]
@@ -223,7 +801,7 @@ property_value: http://purl.org/dc/terms/description "The time that passes betwe
 [Term]
 id: IDO:0000586
 name: infection
-is_a: BFO:0000040
+is_a: BFO:0000040 ! material entity
 is_a: interpretation ! interpretation
 
 [Term]
@@ -234,7 +812,7 @@ is_a: exposure ! exposure
 [Term]
 id: IDO:0000665
 name: source of infection
-is_a: BFO:0000040
+is_a: BFO:0000040 ! material entity
 is_a: interpretation ! interpretation
 
 [Term]
@@ -311,12 +889,12 @@ property_value: http://purl.org/dc/terms/description "It measures the frequency 
 [Term]
 id: OBI:0000011
 name: planned process
-is_a: BFO:0000015
+is_a: BFO:0000015 ! process
 
 [Term]
 id: OBI:0000067
 name: evaluant role
-is_a: BFO:0000023
+is_a: BFO:0000023 ! role
 
 [Term]
 id: OBI:0000070
@@ -326,24 +904,24 @@ is_a: OBI:0000011 ! planned process
 [Term]
 id: OBI:0000181
 name: population
-is_a: BFO:0000040
+is_a: BFO:0000040 ! material entity
 is_a: interpretation ! interpretation
 
 [Term]
 id: OBI:0100026
 name: organism
-is_a: BFO:0000040
+is_a: BFO:0000040 ! material entity
 
 [Term]
 id: OGMS:0000031
 name: disease
-is_a: BFO:0000016
+is_a: BFO:0000016 ! disposition
 is_a: interpretation ! interpretation
 
 [Term]
 id: OGMS:0000063
 name: line of disease
-is_a: BFO:0000015
+is_a: BFO:0000015 ! process
 is_a: descriptive_epidemiology ! descriptive epidemiology
 
 [Term]
@@ -371,7 +949,7 @@ is_a: quantitative_parameters ! quantitative quality
 id: Process
 name: process
 is_a: Processual_Structure ! processual structure
-relationship: projects_to BFO:0000008
+relationship: projects_to BFO:0000008 ! temporal region
 
 [Term]
 id: Processual_Structure
@@ -468,7 +1046,7 @@ is_a: Individual ! individual
 [Term]
 id: TRANS:0000000
 name: transmission
-is_a: BFO:0000015
+is_a: BFO:0000015 ! process
 is_a: interpretation ! interpretation
 
 [Term]
@@ -625,7 +1203,7 @@ property_value: http://purl.org/dc/terms/description "Time for a given quantity 
 [Term]
 id: epidemiological_core_concepts
 name: epidemiological core concepts
-is_a: BFO:0000001
+is_a: BFO:0000001 ! entity
 
 [Term]
 id: etiology
@@ -650,7 +1228,7 @@ is_a: quantitative_parameters ! quantitative quality
 [Term]
 id: exposure
 name: exposure
-is_a: BFO:0000015
+is_a: BFO:0000015 ! process
 is_a: interpretation ! interpretation
 
 [Term]
@@ -716,7 +1294,7 @@ property_value: http://purl.org/dc/terms/description "Represents the proportion 
 [Term]
 id: infectious_process
 name: infectious process
-is_a: BFO:0000015
+is_a: BFO:0000015 ! process
 
 [Term]
 id: initial_exposed_case
@@ -893,7 +1471,7 @@ property_value: http://purl.org/dc/terms/description "Number of daily contacts t
 [Term]
 id: other_indicators
 name: other indicators
-is_a: BFO:0000001
+is_a: BFO:0000001 ! entity
 
 [Term]
 id: per_capita_mobility
@@ -996,7 +1574,7 @@ is_a: quantitative_parameters ! quantitative quality
 [Term]
 id: quantitative_parameters
 name: quantitative quality
-is_a: BFO:0000019
+is_a: BFO:0000019 ! quality
 relationship: IAO:0000136 APOLLO_SV:00000296 ! is about case
 relationship: SIO:000011 NCBITaxon:9606 ! is attribute of person
 
@@ -1111,8 +1689,8 @@ is_a: quantitative_parameters ! quantitative quality
 [Typedef]
 id: BFO:0000054
 name: realized in
-domain: BFO:0000017
-range: BFO:0000015
+domain: BFO:0000017 ! realizable entity
+range: BFO:0000015 ! process
 
 [Typedef]
 id: IAO:0000136
@@ -1130,24 +1708,24 @@ name: has participant
 [Typedef]
 id: RO:0000059
 name: concretizes
-domain: BFO:0000020
-range: BFO:0000031
+domain: BFO:0000020 ! specifically dependent continuant
+range: BFO:0000031 ! generically dependent continuant
 
 [Typedef]
 id: RO:0000086
 name: has quality
-range: BFO:0000019
+range: BFO:0000019 ! quality
 
 [Typedef]
 id: RO:0000087
 name: has role
-domain: BFO:0000004
-range: BFO:0000023
+domain: BFO:0000004 ! independent continuant
+range: BFO:0000023 ! role
 
 [Typedef]
 id: RO:0002234
 name: has output
-domain: BFO:0000015
+domain: BFO:0000015 ! process
 range: IAO:0000030 ! information content entity
 
 [Typedef]
@@ -1171,8 +1749,8 @@ name: is attribute of
 [Typedef]
 id: caused_by
 name: caused by
-domain: BFO:0000015
-range: BFO:0000015
+domain: BFO:0000015 ! process
+range: BFO:0000015 ! process
 
 [Typedef]
 id: has_left_time_boundary


### PR DESCRIPTION
This PR adds instructions for converting the OWL file into OBO and OBO Graph JSON using [`robot`](http://robot.obolibrary.org/convert.html). I also ran these commands and added the artifacts themselves in this PR.

Both of these formats are more standardized and easier to consume. However, there were some issues so I had to turn off strict format compliance with `--check=false`. If there's interest to make improvements in this ontology, better aligning with OBO principles so ontology tooling works better would be very impactful.